### PR TITLE
Update the release workflow in main branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,11 +3,12 @@ name: vSphere Charts
 on:
   push:
     branches:
-      - main
+      - release
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/heads/release')
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR updates the release workflow as we now have release branch. The build and tagging will trigger when a PR gets merged on release branch. 

- [x]  TODO: Update `release.yaml` on `release` branch so that the workflow should run only when a PR is merged into `release` branch.