### PR TITLE
Add permit-os to vsphere-cpi

### DIFF
--- a/charts/rancher-vsphere-cpi/Chart.yaml
+++ b/charts/rancher-vsphere-cpi/Chart.yaml
@@ -3,6 +3,7 @@ annotations:
   catalog.cattle.io/display-name: vSphere CPI
   catalog.cattle.io/namespace: kube-system
   catalog.cattle.io/os: linux
+  catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/rancher-version: '>= 2.6.0-0 <= 2.6.100-0'
   catalog.cattle.io/kube-version: '>= 1.18.0-0 < 1.23.0-0'
   catalog.cattle.io/release-name: vsphere-cpi

--- a/charts/rancher-vsphere-cpi/templates/daemonset.yaml
+++ b/charts/rancher-vsphere-cpi/templates/daemonset.yaml
@@ -44,6 +44,11 @@ spec:
                 operator: In
                 values:
                 - "true"
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - "windows"
       {{- end }}
       {{- if .Values.cloudControllerManager.tolerations }}
       tolerations:


### PR DESCRIPTION
This PR is to port the `permit-os` annotation from https://github.com/rancher/charts/pull/1750