### PR TITLE
CSI 2.5.0 update.

### DIFF
--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -1,14 +1,14 @@
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/display-name: vSphere CSI
-  catalog.cattle.io/kube-version: '>= 1.19.0-0 < 1.23.0-0'
+  catalog.cattle.io/kube-version: '>= 1.21.0-0 < 1.24.0-0'
   catalog.cattle.io/namespace: kube-system
   catalog.cattle.io/os: linux,windows
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/rancher-version: '>= 2.6.0-0 <= 2.6.100-0'
   catalog.cattle.io/release-name: vsphere-csi
 apiVersion: v1
-appVersion: 2.4.1-rancher2
+appVersion: 2.5.0-rancher1
 description: vSphere Cloud Storage Interface (CSI)
 icon: https://charts.rancher.io/assets/logos/vsphere-csi.svg
 keywords:
@@ -19,4 +19,4 @@ maintainers:
 name: rancher-vsphere-csi
 sources:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 2.4.1-rancher2
+version: 2.5.0-rancher1

--- a/charts/rancher-vsphere-csi/questions.yaml
+++ b/charts/rancher-vsphere-csi/questions.yaml
@@ -85,7 +85,7 @@ questions:
 
   - variable: csiWindowsSupport.enabled
     label: Enable CSI Windows Support
-    description: Allows using the topology feature without the need to mount vSphere credentials in the CSI node daemonset
+    description: Enables Windows support.
     type: boolean
     default: false
     group: Driver Configuration

--- a/charts/rancher-vsphere-csi/templates/configmap.yaml
+++ b/charts/rancher-vsphere-csi/templates/configmap.yaml
@@ -9,6 +9,9 @@ data:
   "improved-csi-idempotency": {{ .Values.improvedCsiIdempotency.enabled | quote }}
   "improved-volume-topology": {{ .Values.improvedVolumeTopology.enabled | quote }}
   "csi-windows-support": {{ .Values.csiWindowsSupport.enabled | quote }}
+  "use-csinode-id": {{ .Values.useCsinodeId.enabled | quote }}
+  "pv-to-backingdiskobjectid-mapping": {{ .Values.pvToBackingdiskobjectidMapping.enabled | quote }}
+  "cnsmgr-suspend-create-volume": {{ .Values.cnsmgrSuspendCreateVolume.enabled | quote }}
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/charts/rancher-vsphere-csi/templates/controller/role.yaml
+++ b/charts/rancher-vsphere-csi/templates/controller/role.yaml
@@ -5,8 +5,11 @@ metadata:
   name: vsphere-csi-controller-role
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "persistentvolumeclaims", "pods", "configmaps"]
+    resources: ["nodes", "pods", "configmaps"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims/status"]
     verbs: ["patch"]
@@ -48,7 +51,7 @@ rules:
     verbs: [ "watch", "get", "list" ]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents" ]
-    verbs: [ "create", "get", "list", "watch", "update", "delete" ]
+    verbs: [ "create", "get", "list", "watch", "update", "delete", "patch"]
   - apiGroups: [ "snapshot.storage.k8s.io" ]
     resources: [ "volumesnapshotcontents/status" ]
     verbs: [ "update", "patch" ]

--- a/charts/rancher-vsphere-csi/templates/node/windows-daemonset.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/windows-daemonset.yaml
@@ -99,11 +99,6 @@ spec:
                   fieldPath: metadata.namespace
             - name: NODEGETINFO_WATCH_TIMEOUT_MINUTES
               value: "1"
-          securityContext:
-            privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
-            allowPrivilegeEscalation: true
           volumeMounts:
             - name: plugin-dir
               mountPath: 'C:\csi'

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -25,22 +25,22 @@ csiController:
     enabled: false
   image:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
-    tag: v2.4.1
+    tag: v2.5.0
     csiAttacher:
       repository: rancher/mirrored-sig-storage-csi-attacher
-      tag: v3.3.0
+      tag: v3.4.0
     csiResizer:
       repository: rancher/mirrored-sig-storage-csi-resizer
-      tag: v1.3.0
+      tag: v1.4.0
     livenessProbe:
       repository: rancher/mirrored-sig-storage-livenessprobe
-      tag: v2.4.0
+      tag: v2.6.0
     vsphereSyncer:
       repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
-      tag: v2.4.1
+      tag: v2.5.0
     csiProvisioner:
       repository: rancher/mirrored-sig-storage-csi-provisioner
-      tag: v3.0.0
+      tag: v3.1.0
   ## Node labels for pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
@@ -74,6 +74,12 @@ improvedVolumeTopology:
   enabled: false
 csiWindowsSupport:
   enabled: false
+useCsinodeId:
+  enabled: true
+pvToBackingdiskobjectidMapping:
+  enabled: false
+cnsmgrSuspendCreateVolume:
+  enabled: false
 
 csiNode:
   ## Node labels for pod assignment
@@ -85,13 +91,13 @@ csiNode:
   prefixPath: ""
   image:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
-    tag: v2.4.1
+    tag: v2.5.0
     nodeDriverRegistrar:
       repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
-      tag: v2.3.0
+      tag: v2.5.0
     livenessProbe:
       repository: rancher/mirrored-sig-storage-livenessprobe
-      tag: v2.4.0
+      tag: v2.6.0
 
 storageClass:
   enabled: true


### PR DESCRIPTION
Signed-off-by: Jamie Phillips <jamie.phillips@suse.com>

#### Pull Request Checklist ####

- [x] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] That helm lint and pack run successfully on the chart.
- [ ] Deployment of the chart has been tested and verified that it functions as expected.
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Updating to match the upstream manifests.

#### Linked Issues ####

* https://github.com/rancher/vsphere-charts/issues/13

#### Additional Notes ####

Added in snapshotter support since that is new.

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, please post an announcement in the following channels:

* #discuss-rancher-feature-charts
* #discuss-rancher-feature-vsphere
* #discuss-rancher-k3s-rke2