### PR TITLE
Updating CSI to be a super chart.

### DIFF
--- a/charts/rancher-vsphere-cpi/Chart.yaml
+++ b/charts/rancher-vsphere-cpi/Chart.yaml
@@ -14,7 +14,7 @@ icon: https://charts.rancher.io/assets/logos/vsphere-cpi.svg
 keywords:
 - infrastructure
 maintainers:
-- email: caleb@rancher.com
+- email: jamie.phillips@suse.com
   name: Rancher
 name: rancher-vsphere-cpi
 sources:

--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -1,22 +1,22 @@
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/display-name: vSphere CSI
-  catalog.cattle.io/kube-version: '>= 1.21.0-0 < 1.24.0-0'
+  catalog.cattle.io/kube-version: '>= 1.20.0-0 < 1.24.0-0'
   catalog.cattle.io/namespace: kube-system
   catalog.cattle.io/os: linux,windows
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/rancher-version: '>= 2.6.0-0 <= 2.6.100-0'
   catalog.cattle.io/release-name: vsphere-csi
 apiVersion: v1
-appVersion: 2.5.0-rancher1
+appVersion: 2.5.1-rancher1
 description: vSphere Cloud Storage Interface (CSI)
 icon: https://charts.rancher.io/assets/logos/vsphere-csi.svg
 keywords:
 - infrastructure
 maintainers:
-- email: caleb@rancher.com
+- email: jamie.phillips@suse.com
   name: Rancher
 name: rancher-vsphere-csi
 sources:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 2.5.0-rancher1
+version: 2.5.1-rancher1

--- a/charts/rancher-vsphere-csi/README.md
+++ b/charts/rancher-vsphere-csi/README.md
@@ -9,7 +9,7 @@ The CSI driver for vSphere is `csi.vsphere.vmware.com`.
 ## Prerequisites
 
 - vSphere 6.7 U3+
-- Kubernetes v1.14+
+- Kubernetes v1.20+
 - Out-of-tree vSphere Cloud Provider Interface (CPI)
 - A Secret on your Kubernetes cluster that contains vSphere CSI configuration and credentials
 

--- a/charts/rancher-vsphere-csi/templates/_helpers.tpl
+++ b/charts/rancher-vsphere-csi/templates/_helpers.tpl
@@ -6,6 +6,16 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "applyVersionOverrides" -}}
+{{- $overrides := dict -}}
+{{- range $override := .Values.versionOverrides -}}
+{{- if semverCompare $override.constraint $.Capabilities.KubeVersion.Version -}}
+{{- $_ := mergeOverwrite $overrides $override.values -}}
+{{- end -}}
+{{- end -}}
+{{- $_ := mergeOverwrite .Values $overrides -}}
+{{- end -}}
+
 {{/*
 Windows cluster will add default taint for linux nodes,
 add below linux tolerations to workloads could be scheduled to those linux nodes

--- a/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
+++ b/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
@@ -1,4 +1,4 @@
-# Source: https://github.com/kubernetes-sigs/vsphere-csi-driver
+{{- template "applyVersionOverrides" . -}}
 kind: Deployment
 apiVersion: apps/v1
 metadata:

--- a/charts/rancher-vsphere-csi/templates/controller/role-binding.yaml
+++ b/charts/rancher-vsphere-csi/templates/controller/role-binding.yaml
@@ -1,4 +1,3 @@
-# Source: https://github.com/kubernetes-sigs/vsphere-csi-driver
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/rancher-vsphere-csi/templates/controller/role.yaml
+++ b/charts/rancher-vsphere-csi/templates/controller/role.yaml
@@ -1,4 +1,3 @@
-# Source: https://github.com/kubernetes-sigs/vsphere-csi-driver
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/rancher-vsphere-csi/templates/controller/service-account.yaml
+++ b/charts/rancher-vsphere-csi/templates/controller/service-account.yaml
@@ -1,4 +1,3 @@
-# Source: https://github.com/kubernetes-sigs/vsphere-csi-driver
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/charts/rancher-vsphere-csi/templates/controller/service.yaml
+++ b/charts/rancher-vsphere-csi/templates/controller/service.yaml
@@ -1,4 +1,3 @@
-# Source: https://github.com/kubernetes-sigs/vsphere-csi-driver
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
@@ -1,4 +1,4 @@
-# Source: https://github.com/kubernetes-sigs/vsphere-csi-driver
+{{- template "applyVersionOverrides" . -}}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:

--- a/charts/rancher-vsphere-csi/templates/node/role-binding.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/role-binding.yaml
@@ -1,4 +1,3 @@
-# Source: https://github.com/kubernetes-sigs/vsphere-csi-driver
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/rancher-vsphere-csi/templates/node/role.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/role.yaml
@@ -1,4 +1,3 @@
-# Source: https://github.com/kubernetes-sigs/vsphere-csi-driver
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/rancher-vsphere-csi/templates/node/service-account.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/service-account.yaml
@@ -1,4 +1,3 @@
-# Source: https://github.com/kubernetes-sigs/vsphere-csi-driver
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/charts/rancher-vsphere-csi/templates/node/windows-daemonset.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/windows-daemonset.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.csiWindowsSupport.enabled }}
+{{- template "applyVersionOverrides" . -}}
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -25,7 +25,7 @@ csiController:
     enabled: false
   image:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
-    tag: v2.5.0
+    tag: v2.5.1
     csiAttacher:
       repository: rancher/mirrored-sig-storage-csi-attacher
       tag: v3.4.0
@@ -37,7 +37,7 @@ csiController:
       tag: v2.6.0
     vsphereSyncer:
       repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
-      tag: v2.5.0
+      tag: v2.5.1
     csiProvisioner:
       repository: rancher/mirrored-sig-storage-csi-provisioner
       tag: v3.1.0
@@ -91,7 +91,7 @@ csiNode:
   prefixPath: ""
   image:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
-    tag: v2.5.0
+    tag: v2.5.1
     nodeDriverRegistrar:
       repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
       tag: v2.5.0
@@ -110,3 +110,67 @@ storageClass:
 global:
   cattle:
     systemDefaultRegistry: ""
+
+versionOverrides:
+  - constraint: ">= 1.21 < 1.24"
+    values:
+      csiController:
+        image:
+          repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
+          tag: v2.5.1
+          csiAttacher:
+            repository: rancher/mirrored-sig-storage-csi-attacher
+            tag: v3.4.0
+          csiResizer:
+            repository: rancher/mirrored-sig-storage-csi-resizer
+            tag: v1.4.0
+          livenessProbe:
+            repository: rancher/mirrored-sig-storage-livenessprobe
+            tag: v2.6.0
+          vsphereSyncer:
+            repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
+            tag: v2.5.1
+          csiProvisioner:
+            repository: rancher/mirrored-sig-storage-csi-provisioner
+            tag: v3.1.0
+      csiNode:
+        image:
+          repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
+          tag: v2.5.1
+          nodeDriverRegistrar:
+            repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
+            tag: v2.5.0
+          livenessProbe:
+            repository: rancher/mirrored-sig-storage-livenessprobe
+            tag: v2.6.0
+  - constraint: "~ 1.20"
+    values:
+      csiController:
+        image:
+          repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
+          tag: v2.4.1
+          csiAttacher:
+            repository: rancher/mirrored-sig-storage-csi-attacher
+            tag: v3.3.0
+          csiResizer:
+            repository: rancher/mirrored-sig-storage-csi-resizer
+            tag: v1.3.0
+          livenessProbe:
+            repository: rancher/mirrored-sig-storage-livenessprobe
+            tag: v2.4.0
+          vsphereSyncer:
+            repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
+            tag: v2.4.1
+          csiProvisioner:
+            repository: rancher/mirrored-sig-storage-csi-provisioner
+            tag: v3.0.0
+      csiNode:
+        image:
+          repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
+          tag: v2.4.1
+          nodeDriverRegistrar:
+            repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
+            tag: v2.3.0
+          livenessProbe:
+            repository: rancher/mirrored-sig-storage-livenessprobe
+            tag: v2.4.0

--- a/tests/unit/cpi_template_test.go
+++ b/tests/unit/cpi_template_test.go
@@ -43,7 +43,7 @@ func TestCPITemplateRenderedDaemonset(t *testing.T) {
 			name: "Kubernetes 1.22",
 			args: args{
 				values:        map[string]string{},
-				kubeVersion:   "1.23",
+				kubeVersion:   "1.22",
 				namespace:     "cpitest-" + strings.ToLower(random.UniqueId()),
 				releaseName:   "cpitest-" + strings.ToLower(random.UniqueId()),
 				chartRelPath:  cpiChart,
@@ -115,7 +115,7 @@ func TestCPITemplateRenderedDaemonset(t *testing.T) {
 			// assert
 			require.Equal(t, tt.args.namespace, daemonSet.Namespace)
 			daemonSetContainers := daemonSet.Spec.Template.Spec.Containers
-			require.Equal(t, len(daemonSetContainers), 1)
+			require.Equal(t, 1, len(daemonSetContainers))
 			require.Equal(t, tt.args.expectedImage, daemonSetContainers[0].Image)
 		})
 	}

--- a/tests/unit/csi_template_test.go
+++ b/tests/unit/csi_template_test.go
@@ -1,0 +1,370 @@
+package unit
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+const csiChart = "../../charts/rancher-vsphere-csi"
+
+func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
+	type args struct {
+		values         map[string]string
+		kubeVersion    string
+		namespace      string
+		releaseName    string
+		chartRelPath   string
+		windowsEnabled bool
+		expectedImages []string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "Kubernetes 1.23 Linux Only",
+			args: args{
+				values:         map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:    "1.23",
+				namespace:      "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:    "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:   csiChart,
+				windowsEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.1",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.6.0",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.23 Linux and Windows",
+			args: args{
+				values: map[string]string{
+					"vCenter.clusterId":         random.UniqueId(),
+					"csiWindowsSupport:enabled": "true",
+				},
+				kubeVersion:  "1.23",
+				namespace:    "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:  "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath: csiChart,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.1",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.6.0",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.22 Linux Only",
+			args: args{
+				values:         map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:    "1.22",
+				namespace:      "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:    "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:   csiChart,
+				windowsEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.1",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.6.0",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.22 Linux and Windows",
+			args: args{
+				values: map[string]string{
+					"vCenter.clusterId":         random.UniqueId(),
+					"csiWindowsSupport:enabled": "true",
+				},
+				kubeVersion:  "1.22",
+				namespace:    "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:  "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath: csiChart,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.1",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.6.0",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.21 Linux Only",
+			args: args{
+				values:         map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:    "1.21",
+				namespace:      "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:    "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:   csiChart,
+				windowsEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.1",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.6.0",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.21 Linux and Windows",
+			args: args{
+				values: map[string]string{
+					"vCenter.clusterId":         random.UniqueId(),
+					"csiWindowsSupport:enabled": "true",
+				},
+				kubeVersion:  "1.21",
+				namespace:    "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:  "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath: csiChart,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.1",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.6.0",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.20 Linux Only",
+			args: args{
+				values:         map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:    "1.20",
+				namespace:      "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:    "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:   csiChart,
+				windowsEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.3.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.4.1",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.4.0",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.21 Linux and Windows",
+			args: args{
+				values: map[string]string{
+					"vCenter.clusterId":         random.UniqueId(),
+					"csiWindowsSupport:enabled": "true",
+				},
+				kubeVersion:  "1.21",
+				namespace:    "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:  "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath: csiChart,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.1",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.6.0",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// arrange
+			chartPath, err := filepath.Abs(tt.args.chartRelPath)
+			require.NoError(t, err)
+
+			options := &helm.Options{
+				SetValues:      tt.args.values,
+				KubectlOptions: k8s.NewKubectlOptions("", "", tt.args.namespace),
+			}
+
+			// act
+			output := helm.RenderTemplate(t, options, chartPath, tt.args.releaseName, []string{"templates/node/daemonset.yaml"}, "--kube-version", tt.args.kubeVersion)
+
+			var daemonSet appsv1.DaemonSet
+			helm.UnmarshalK8SYaml(t, output, &daemonSet)
+
+			// assert
+			require.Equal(t, tt.args.namespace, daemonSet.Namespace)
+			daemonSetContainers := daemonSet.Spec.Template.Spec.Containers
+			require.Equal(t, len(tt.args.expectedImages), len(daemonSetContainers))
+			for i := range tt.args.expectedImages {
+				require.Equal(t, tt.args.expectedImages[i], daemonSetContainers[i].Image)
+			}
+
+			if tt.args.windowsEnabled {
+				// act
+				windowsOutput := helm.RenderTemplate(t, options, chartPath, tt.args.releaseName, []string{"templates/node/windows-daemonset.yaml"}, "--kube-version", tt.args.kubeVersion)
+
+				var windowsDaemonSet appsv1.DaemonSet
+				helm.UnmarshalK8SYaml(t, windowsOutput, &daemonSet)
+
+				// assert
+				require.Equal(t, tt.args.namespace, windowsDaemonSet.Namespace)
+				windowsDaemonSetSetContainers := windowsDaemonSet.Spec.Template.Spec.Containers
+				require.Equal(t, len(tt.args.expectedImages), len(windowsDaemonSetSetContainers))
+				for i := range tt.args.expectedImages {
+					require.Equal(t, tt.args.expectedImages[i], windowsDaemonSetSetContainers[i].Image)
+				}
+			}
+		})
+	}
+}
+
+func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
+	type args struct {
+		values            map[string]string
+		kubeVersion       string
+		namespace         string
+		releaseName       string
+		chartRelPath      string
+		csiResizerEnabled bool
+		expectedImages    []string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "Kubernetes 1.23",
+			args: args{
+				values:            map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:       "1.23",
+				namespace:         "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:       "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:      csiChart,
+				csiResizerEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-attacher:v3.4.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.1",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.5.1",
+					"rancher/mirrored-sig-storage-csi-provisioner:v3.1.0",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.22",
+			args: args{
+				values:            map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:       "1.22",
+				namespace:         "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:       "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:      csiChart,
+				csiResizerEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-attacher:v3.4.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.1",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.5.1",
+					"rancher/mirrored-sig-storage-csi-provisioner:v3.1.0",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.21",
+			args: args{
+				values:            map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:       "1.21",
+				namespace:         "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:       "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:      csiChart,
+				csiResizerEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-attacher:v3.4.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.1",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.5.1",
+					"rancher/mirrored-sig-storage-csi-provisioner:v3.1.0",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.20",
+			args: args{
+				values:            map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:       "1.20",
+				namespace:         "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:       "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:      csiChart,
+				csiResizerEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-attacher:v3.3.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.4.1",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.4.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.4.1",
+					"rancher/mirrored-sig-storage-csi-provisioner:v3.0.0",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.23 with CSI Resizer Enabled",
+			args: args{
+				values: map[string]string{
+					"vCenter.clusterId":                random.UniqueId(),
+					"csiController.csiResizer.enabled": "true",
+				},
+				kubeVersion:       "1.23",
+				namespace:         "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:       "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:      csiChart,
+				csiResizerEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-attacher:v3.4.0",
+					"rancher/mirrored-sig-storage-csi-resizer:v1.4.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.1",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.5.1",
+					"rancher/mirrored-sig-storage-csi-provisioner:v3.1.0",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.20 with CSI Resizer Enabled",
+			args: args{
+				values: map[string]string{
+					"vCenter.clusterId":                random.UniqueId(),
+					"csiController.csiResizer.enabled": "true",
+				},
+				kubeVersion:       "1.20",
+				namespace:         "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:       "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:      csiChart,
+				csiResizerEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-attacher:v3.3.0",
+					"rancher/mirrored-sig-storage-csi-resizer:v1.3.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.4.1",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.4.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.4.1",
+					"rancher/mirrored-sig-storage-csi-provisioner:v3.0.0",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// arrange
+			chartPath, err := filepath.Abs(tt.args.chartRelPath)
+			require.NoError(t, err)
+
+			options := &helm.Options{
+				SetValues:      tt.args.values,
+				KubectlOptions: k8s.NewKubectlOptions("", "", tt.args.namespace),
+			}
+
+			// act
+			output := helm.RenderTemplate(t, options, chartPath, tt.args.releaseName, []string{"templates/controller/deployment.yaml"}, "--kube-version", tt.args.kubeVersion)
+
+			var deployment appsv1.Deployment
+			helm.UnmarshalK8SYaml(t, output, &deployment)
+
+			// assert
+			require.Equal(t, tt.args.namespace, deployment.Namespace)
+			deploymentSetContainers := deployment.Spec.Template.Spec.Containers
+
+			require.Equal(t, len(tt.args.expectedImages), len(deploymentSetContainers))
+			for i := range tt.args.expectedImages {
+				require.Equal(t, tt.args.expectedImages[i], deploymentSetContainers[i].Image)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This makes the CSI chart a super chart. It can pick the correct version of CSI based on the Kubernetes Version of your cluster. It currently supports 2.4.1 and 2.5.1, for Kubernetes 1.20+. I also added unit tests for the CSI chart.

#### Pull Request Checklist ####

- [x] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

New images, version bump, and unit tests.

#### Linked Issues ####

* https://github.com/rancher/rancher/issues/37005

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, please post an announcement in the following channels:

* #discuss-rancher-feature-charts
* #discuss-rancher-feature-vsphere
* #discuss-rancher-k3s-rke2