### PR TITLE
feat(rancher-vsphere-cpi): add labels option to vCenter 

### DIFF
--- a/charts/rancher-vsphere-cpi/Chart.yaml
+++ b/charts/rancher-vsphere-cpi/Chart.yaml
@@ -19,4 +19,4 @@ maintainers:
 name: rancher-vsphere-cpi
 sources:
 - https://github.com/kubernetes/cloud-provider-vsphere
-version: 1.2.1
+version: 1.3.0

--- a/charts/rancher-vsphere-cpi/questions.yaml
+++ b/charts/rancher-vsphere-cpi/questions.yaml
@@ -40,3 +40,23 @@ questions:
     type: string
     group: Configuration
     show_if: "vCenter.credentialsSecret.generate=false"
+
+  - variable: vCenter.labels.generate
+    label: Define vSphere Tags
+    description: "vSphere Tags used to determine the zone and region of a Kubernetes node. This labels will be propagated to NodeLabels"
+    type: boolean
+    default: true
+    required: true
+    group: Configuration
+    show_subquestion_if: true
+    subquestions:
+      - variable: labels.region
+        label: Region
+        description: vSphere tag which will used to define regions. e.g. eu-central
+        type: string
+        group: Configuration
+      - variable: labels.zone
+        label: Zone
+        description: vSphere tag which will used to define availability zones
+        type: string
+        group: Configuration

--- a/charts/rancher-vsphere-cpi/templates/configmap.yaml
+++ b/charts/rancher-vsphere-cpi/templates/configmap.yaml
@@ -7,14 +7,14 @@ metadata:
     component: {{ .Chart.Name }}-cloud-controller-manager
   namespace: {{ .Release.Namespace }}
 data:
-  vsphere.conf: |
+  vsphere.yaml: |
     # Global properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.
     {{ with .Values.vCenter }}
     global:
       secretName: {{ .credentialsSecret.name | quote }}
       secretNamespace: {{ $.Release.Namespace | quote }}
-      port: {{ .port | quote }}
-      insecureFlag: {{ .insecureFlag | quote }}
+      port: {{ .port }}
+      insecureFlag: {{ .insecureFlag }}
 
     vcenter:
       {{ .host | quote }}:

--- a/charts/rancher-vsphere-cpi/templates/configmap.yaml
+++ b/charts/rancher-vsphere-cpi/templates/configmap.yaml
@@ -8,11 +8,24 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   vsphere.conf: |
-    [Global]
-    secret-name = {{ .Values.vCenter.credentialsSecret.name | quote }}
-    secret-namespace = {{ .Release.Namespace | quote }}
-    port = {{ .Values.vCenter.port | quote }}
-    insecure-flag = {{ .Values.vCenter.insecureFlag | quote }}
+    # Global properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.
+    {{ with .Values.vCenter }}
+    global:
+      secretName: {{ .credentialsSecret.name | quote }}
+      secretNamespace: {{ $.Release.Namespace | quote }}
+      port: {{ .port | quote }}
+      insecureFlag: {{ .insecureFlag | quote }}
 
-    [VirtualCenter {{ .Values.vCenter.host | quote }}]
-    datacenters = {{ .Values.vCenter.datacenters | quote }}
+    vcenter:
+      {{ .host | quote }}:
+        server: {{ .host | quote }}
+        user: {{ .username }}
+        password: {{ .password }}
+        datacenters:
+          - {{ .datacenters | quote }}
+    {{- if .labels.generate }}
+    labels:
+      region: {{ .labels.region }}
+      zone: {{ .labels.zone }}
+    {{- end }}
+    {{- end }}

--- a/charts/rancher-vsphere-cpi/templates/daemonset.yaml
+++ b/charts/rancher-vsphere-cpi/templates/daemonset.yaml
@@ -86,7 +86,7 @@ spec:
           args:
             - --cloud-provider=vsphere
             - --v=2
-            - --cloud-config=/etc/cloud/vsphere.conf
+            - --cloud-config=/etc/cloud/vsphere.yaml
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume

--- a/charts/rancher-vsphere-cpi/values.yaml
+++ b/charts/rancher-vsphere-cpi/values.yaml
@@ -1,7 +1,7 @@
 vCenter:
   host: ""
   port: 443
-  insecureFlag: "1"
+  insecureFlag: true
   datacenters: ""
   username: ""
   password: ""

--- a/charts/rancher-vsphere-cpi/values.yaml
+++ b/charts/rancher-vsphere-cpi/values.yaml
@@ -9,6 +9,11 @@ vCenter:
     name: "vsphere-cpi-creds"
     generate: true
 
+# vSphere Tags used to determine the zone and region of a Kubernetes node. This labels will be propagated to NodeLabels
+  labels:
+    region: "k8s-region"
+    zone: "k8s-zone"
+
 # A list of Semver constraint strings (defined by https://github.com/Masterminds/semver) and values.yaml overrides.
 #
 # For each key in versionOvverides, this chart will check to see if the current Kubernetes cluster's version matches


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

- added the labels configuration to `vsphere.conf`. This allows to propagate regions and availability zones to nodes and the vSphere CSI
- use YAML instead of INI as this is recommended as of `v1.2.0`

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

https://cloud-provider-vsphere.sigs.k8s.io/tutorials/kubernetes-on-vsphere-with-kubeadm.html
> NOTE: As of CPI version 1.2.0 or higher, the preferred cloud-config format will be YAML based. The INI based format will be deprecated but supported until the transition to the preferred YAML based configuration has been completed. This deprecation notice will be placed in the CPI logs when using the INI based configuration format.

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, please post an announcement in the following channels:

* #discuss-rancher-feature-charts
* #discuss-rancher-feature-vsphere
* #discuss-rancher-k3s-rke2