### PR TITLE
Updating CPI chart to include new image.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,1 @@
-* @phillipsj
-* @luthermonson
-* @rosskirkpat
-* @sirredbeard
-* @PennyScissors
-* @aiyengar2
+* @phillipsj @luthermonson @rosskirkpat @sirredbeard @PennyScissors

--- a/charts/rancher-vsphere-cpi/Chart.yaml
+++ b/charts/rancher-vsphere-cpi/Chart.yaml
@@ -1,14 +1,14 @@
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/display-name: vSphere CPI
-  catalog.cattle.io/kube-version: '>= 1.18.0-0 < 1.24.0-0'
+  catalog.cattle.io/kube-version: '>= 1.18.0-0 < 1.25.0-0'
   catalog.cattle.io/namespace: kube-system
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/rancher-version: '>= 2.6.0-0 <= 2.6.100-0'
   catalog.cattle.io/release-name: vsphere-cpi
 apiVersion: v1
-appVersion: 1.2.1
+appVersion: 1.2.2
 description: vSphere Cloud Provider Interface (CPI)
 icon: https://charts.rancher.io/assets/logos/vsphere-cpi.svg
 keywords:
@@ -19,4 +19,4 @@ maintainers:
 name: rancher-vsphere-cpi
 sources:
 - https://github.com/kubernetes/cloud-provider-vsphere
-version: 1.2.1
+version: 1.2.2

--- a/charts/rancher-vsphere-cpi/values.yaml
+++ b/charts/rancher-vsphere-cpi/values.yaml
@@ -22,7 +22,12 @@ vCenter:
 # - On running a helm template, Helm generally assumes the kubeVersion is v1.20.0
 # - On running a helm install --dry-run, the correct kubeVersion should be chosen.
 versionOverrides:
-  - constraint: ">= 1.22 < 1.24"
+  - constraint: ">= 1.23 < 1.25"
+    values:
+      cloudControllerManager:
+        repository: rancher/mirrored-cloud-provider-vsphere-cpi-release-manager
+        tag: v1.23.0
+  - constraint: "~ 1.22"
     values:
       cloudControllerManager:
         repository: rancher/mirrored-cloud-provider-vsphere-cpi-release-manager

--- a/tests/unit/cpi_template_test.go
+++ b/tests/unit/cpi_template_test.go
@@ -29,6 +29,17 @@ func TestCPITemplateRenderedDaemonset(t *testing.T) {
 		args args
 	}{
 		{
+			name: "Kubernetes 1.24",
+			args: args{
+				values:        map[string]string{},
+				kubeVersion:   "1.24",
+				namespace:     "cpitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:   "cpitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:  cpiChart,
+				expectedImage: "rancher/mirrored-cloud-provider-vsphere-cpi-release-manager:v1.23.0",
+			},
+		},
+		{
 			name: "Kubernetes 1.23",
 			args: args{
 				values:        map[string]string{},
@@ -36,7 +47,7 @@ func TestCPITemplateRenderedDaemonset(t *testing.T) {
 				namespace:     "cpitest-" + strings.ToLower(random.UniqueId()),
 				releaseName:   "cpitest-" + strings.ToLower(random.UniqueId()),
 				chartRelPath:  cpiChart,
-				expectedImage: "rancher/mirrored-cloud-provider-vsphere-cpi-release-manager:v1.22.6",
+				expectedImage: "rancher/mirrored-cloud-provider-vsphere-cpi-release-manager:v1.23.0",
 			},
 		},
 		{


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Updating CPI chart to use the new 1.23 CPI image and support 1.24 through skew policy.

#### Linked Issues ####

* https://github.com/rancher/rancher/issues/37319

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, please post an announcement in the following channels:

* #discuss-rancher-feature-charts
* #discuss-rancher-feature-vsphere
* #discuss-rancher-k3s-rke2