### PR TITLE
Update rancher-version annotation

### DIFF
--- a/charts/rancher-vsphere-cpi/Chart.yaml
+++ b/charts/rancher-vsphere-cpi/Chart.yaml
@@ -5,7 +5,7 @@ annotations:
   catalog.cattle.io/namespace: kube-system
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux,windows
-  catalog.cattle.io/rancher-version: '>= 2.6.0-0 <= 2.6.100-0'
+  catalog.cattle.io/rancher-version: '>= 2.6.0-0 < 2.7.0-0'
   catalog.cattle.io/release-name: vsphere-cpi
 apiVersion: v1
 appVersion: 1.2.2

--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -5,7 +5,7 @@ annotations:
   catalog.cattle.io/namespace: kube-system
   catalog.cattle.io/os: linux,windows
   catalog.cattle.io/permits-os: linux,windows
-  catalog.cattle.io/rancher-version: '>= 2.6.0-0 <= 2.6.100-0'
+  catalog.cattle.io/rancher-version: '>= 2.6.0-0 < 2.7.0-0'
   catalog.cattle.io/release-name: vsphere-csi
 apiVersion: v1
 appVersion: 2.5.1-rancher1


### PR DESCRIPTION
Minor change to the rancher-version annotation of the vsphere charts to port the changes that will be done in [this](https://github.com/rancher/charts/pull/1923) PR