### PR TITLE
update the CSI chart to match the upstream vsphere-csi-driver v2.6.0 which supports k8s 1.24

### DIFF
--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
   catalog.cattle.io/rancher-version: '>= 2.6.0-0 < 2.7.0-0'
   catalog.cattle.io/release-name: vsphere-csi
 apiVersion: v1
-appVersion: 2.5.1-rancher1
+appVersion: 2.6.0-rancher1
 description: vSphere Cloud Storage Interface (CSI)
 icon: https://charts.rancher.io/assets/logos/vsphere-csi.svg
 keywords:
@@ -19,4 +19,4 @@ maintainers:
 name: rancher-vsphere-csi
 sources:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 2.5.1-rancher1
+version: 2.6.0-rancher1

--- a/charts/rancher-vsphere-csi/templates/configmap.yaml
+++ b/charts/rancher-vsphere-csi/templates/configmap.yaml
@@ -8,10 +8,14 @@ data:
   "async-query-volume": {{ .Values.asyncQueryVolume.enabled | quote }}
   "improved-csi-idempotency": {{ .Values.improvedCsiIdempotency.enabled | quote }}
   "improved-volume-topology": {{ .Values.improvedVolumeTopology.enabled | quote }}
+  "block-volume-snapshot": {{ .Values.blockVolumeSnapshot.enabled | quote }}
   "csi-windows-support": {{ .Values.csiWindowsSupport.enabled | quote }}
   "use-csinode-id": {{ .Values.useCsinodeId.enabled | quote }}
+  "list-volumes": {{ .Values.listVolumes.enabled | quote }}
   "pv-to-backingdiskobjectid-mapping": {{ .Values.pvToBackingdiskobjectidMapping.enabled | quote }}
   "cnsmgr-suspend-create-volume": {{ .Values.cnsmgrSuspendCreateVolume.enabled | quote }}
+  "topology-preferential-datastores": {{ .Values.topologyPreferentialDatastores.enabled | quote }}
+  "max-pvscsi-targets-per-vm": {{ .Values.maxPvscsiTargetsPerVm.enabled | quote }}
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
+++ b/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
@@ -111,7 +111,9 @@ spec:
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
+            {{- if semverCompare "< 1.24" $.Capabilities.KubeVersion.Version }}
             - "--use-gocsi=false"
+            {{- end }}
           imagePullPolicy: "Always"
           env:
             - name: CSI_ENDPOINT

--- a/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
@@ -88,7 +88,9 @@ spec:
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
+            {{- if semverCompare "< 1.24" $.Capabilities.KubeVersion.Version }}
             - "--use-gocsi=false"
+            {{- end }}
           imagePullPolicy: "Always"
           env:
             - name: NODE_NAME

--- a/charts/rancher-vsphere-csi/templates/node/role.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/role.yaml
@@ -15,7 +15,11 @@ metadata:
 rules:
   - apiGroups: ["cns.vmware.com"]
     resources: ["csinodetopologies"]
+{{- if semverCompare ">= 1.21" $.Capabilities.KubeVersion.Version }}
+    verbs: ["create", "watch", "get", "patch"]
+{{- else }}
     verbs: ["create", "watch"]
+{{- end }}
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get"]

--- a/charts/rancher-vsphere-csi/templates/node/windows-daemonset.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/windows-daemonset.yaml
@@ -50,7 +50,9 @@ spec:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+            {{- if semverCompare "< 1.24" $.Capabilities.KubeVersion.Version }}
             - "--health-port=9809"
+            {{- end }}
           env:
             - name: ADDRESS
               value: 'unix://C:\\csi\\csi.sock'

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -72,13 +72,21 @@ improvedCsiIdempotency:
   enabled: false
 improvedVolumeTopology:
   enabled: false
+blockVolumeSnapshot:
+  enabled: false
 csiWindowsSupport:
   enabled: false
 useCsinodeId:
   enabled: true
+listVolumes:
+  enabled: false
 pvToBackingdiskobjectidMapping:
   enabled: false
 cnsmgrSuspendCreateVolume:
+  enabled: false
+topologyPreferentialDatastores:
+  enabled: false
+maxPvscsiTargetsPerVm:
   enabled: false
 
 csiNode:
@@ -112,6 +120,37 @@ global:
     systemDefaultRegistry: ""
 
 versionOverrides:
+  - constraint: ">= 1.24"
+    values:
+      csiController:
+        image:
+          repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
+          tag: v2.6.0
+          csiAttacher:
+            repository: rancher/mirrored-sig-storage-csi-attacher
+            tag: v3.4.0
+          csiResizer:
+            repository: rancher/mirrored-sig-storage-csi-resizer
+            tag: v1.4.0
+          livenessProbe:
+            repository: rancher/mirrored-sig-storage-livenessprobe
+            tag: v2.7.0
+          vsphereSyncer:
+            repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
+            tag: v2.6.0
+          csiProvisioner:
+            repository: rancher/mirrored-sig-storage-csi-provisioner
+            tag: v3.2.1
+      csiNode:
+        image:
+          repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
+          tag: v2.6.0
+          nodeDriverRegistrar:
+            repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
+            tag: v2.5.1
+          livenessProbe:
+            repository: rancher/mirrored-sig-storage-livenessprobe
+            tag: v2.7.0
   - constraint: ">= 1.21 < 1.24"
     values:
       csiController:


### PR DESCRIPTION


#### Pull Request Checklist ####

- [x] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.
- [ ]  (N/A)~Changes to scripting or CI config have been tested to the best of your ability~

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->

- update the CSI chart to match the upstream vsphere-csi-driver v2.6.0 which supports k8s 1.24 
   source: https://github.com/kubernetes-sigs/vsphere-csi-driver/releases/tag/v2.6.0
- update test cases 

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->
https://github.com/rancher/rancher/issues/38188

#### Additional Notes ####

<!-- Any additional details / test results / etc --> 

The following tests are done on rancher 2.6.8:
- provision a 1.23 RKE1 vSphere node-driver cluster
- install the CPI and CSI chart from my local branch 
- confirm the apps are running and using the correct images for  k8s 1.23
- deploy a workload that uses PVC backed by the storage class
- conform the pod are active, and I can write file to the volume 
- upgrade the cluster to 1.24 
- upgrade the CPI and CSI chart from my local branch 
- confirm the apps are running and using the correct images for  k8s 1.24
- confirm the existing pod works
- confirm the data is preserved on the new pod if the old pod is removed 
- deploy a workload that uses PVC backed by the storage class
- conform the pod are active, and I can write file to the volume 



#### After the PR is merged ####

Once the PR is merged, typically upon a new release, please post an announcement in the following channels:

* #discuss-rancher-feature-charts
* #discuss-rancher-feature-vsphere
* #discuss-rancher-k3s-rke2