### PR TITLE
Update CSI and CPI chart image versions

### DIFF
--- a/charts/rancher-vsphere-cpi/values.yaml
+++ b/charts/rancher-vsphere-cpi/values.yaml
@@ -28,10 +28,10 @@ vCenter:
 # - On running a helm install --dry-run, the correct kubeVersion should be chosen.
 versionOverrides:
   - constraint: "~ 1.25"
-      values:
-        cloudControllerManager:
-          repository: rancher/mirrored-cloud-provider-vsphere-cpi-release-manager
-          tag: v1.25.0
+    values:
+      cloudControllerManager:
+        repository: rancher/mirrored-cloud-provider-vsphere-cpi-release-manager
+        tag: v1.25.0
   - constraint: ">= 1.24 < 1.25"
     values:
       cloudControllerManager:

--- a/charts/rancher-vsphere-cpi/values.yaml
+++ b/charts/rancher-vsphere-cpi/values.yaml
@@ -27,11 +27,16 @@ vCenter:
 # - On running a helm template, Helm generally assumes the kubeVersion is v1.20.0
 # - On running a helm install --dry-run, the correct kubeVersion should be chosen.
 versionOverrides:
-  - constraint: ">= 1.24 < 1.26"
+  - constraint: "~ 1.25"
+      values:
+        cloudControllerManager:
+          repository: rancher/mirrored-cloud-provider-vsphere-cpi-release-manager
+          tag: v1.25.0
+  - constraint: ">= 1.24 < 1.25"
     values:
       cloudControllerManager:
         repository: rancher/mirrored-cloud-provider-vsphere-cpi-release-manager
-        tag: v1.24.1
+        tag: v1.24.2
   - constraint: ">= 1.23 < 1.24"
     values:
       cloudControllerManager:

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -120,12 +120,44 @@ global:
     systemDefaultRegistry: ""
 
 versionOverrides:
-  - constraint: ">= 1.24 < 1.26"
+  - constraint: "~ 1.25"
+      values:
+        csiController:
+          image:
+            repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
+            tag: v2.7.0
+            csiAttacher:
+              repository: rancher/mirrored-sig-storage-csi-attacher
+              tag: v3.4.0
+            csiResizer:
+              repository: rancher/mirrored-sig-storage-csi-resizer
+              tag: v1.4.0
+            livenessProbe:
+              repository: rancher/mirrored-sig-storage-livenessprobe
+              tag: v2.7.0
+            vsphereSyncer:
+              repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
+              tag: v2.7.0
+            csiProvisioner:
+              repository: rancher/mirrored-sig-storage-csi-provisioner
+              tag: v3.2.1
+        csiNode:
+          image:
+            repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
+            tag: v2.7.0
+            nodeDriverRegistrar:
+              repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
+              tag: v2.5.1
+            livenessProbe:
+              repository: rancher/mirrored-sig-storage-livenessprobe
+              tag: v2.7.0
+
+  - constraint: ">= 1.24 < 1.25"
     values:
       csiController:
         image:
           repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
-          tag: v2.6.1
+          tag: v2.6.2
           csiAttacher:
             repository: rancher/mirrored-sig-storage-csi-attacher
             tag: v3.4.0
@@ -137,14 +169,14 @@ versionOverrides:
             tag: v2.7.0
           vsphereSyncer:
             repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
-            tag: v2.6.1
+            tag: v2.6.2
           csiProvisioner:
             repository: rancher/mirrored-sig-storage-csi-provisioner
             tag: v3.2.1
       csiNode:
         image:
           repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
-          tag: v2.6.1
+          tag: v2.6.2
           nodeDriverRegistrar:
             repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
             tag: v2.5.1
@@ -168,7 +200,7 @@ versionOverrides:
             tag: v2.6.0
           vsphereSyncer:
             repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
-            tag: v2.5.3
+            tag: v2.5.4
           csiProvisioner:
             repository: rancher/mirrored-sig-storage-csi-provisioner
             tag: v3.1.0

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -25,7 +25,7 @@ csiController:
     enabled: false
   image:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
-    tag: v2.5.2
+    tag: v2.6.2
     csiAttacher:
       repository: rancher/mirrored-sig-storage-csi-attacher
       tag: v3.4.0
@@ -37,7 +37,7 @@ csiController:
       tag: v2.6.0
     vsphereSyncer:
       repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
-      tag: v2.5.1
+      tag: v2.6.2
     csiProvisioner:
       repository: rancher/mirrored-sig-storage-csi-provisioner
       tag: v3.1.0
@@ -99,7 +99,7 @@ csiNode:
   prefixPath: ""
   image:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
-    tag: v2.5.2
+    tag: v2.6.2
     nodeDriverRegistrar:
       repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
       tag: v2.5.0
@@ -121,37 +121,36 @@ global:
 
 versionOverrides:
   - constraint: "~ 1.25"
-      values:
-        csiController:
-          image:
-            repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
+    values:
+      csiController:
+        image:
+          repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
+          tag: v2.7.0
+          csiAttacher:
+            repository: rancher/mirrored-sig-storage-csi-attacher
+            tag: v3.4.0
+          csiResizer:
+            repository: rancher/mirrored-sig-storage-csi-resizer
+            tag: v1.4.0
+          livenessProbe:
+            repository: rancher/mirrored-sig-storage-livenessprobe
             tag: v2.7.0
-            csiAttacher:
-              repository: rancher/mirrored-sig-storage-csi-attacher
-              tag: v3.4.0
-            csiResizer:
-              repository: rancher/mirrored-sig-storage-csi-resizer
-              tag: v1.4.0
-            livenessProbe:
-              repository: rancher/mirrored-sig-storage-livenessprobe
-              tag: v2.7.0
-            vsphereSyncer:
-              repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
-              tag: v2.7.0
-            csiProvisioner:
-              repository: rancher/mirrored-sig-storage-csi-provisioner
-              tag: v3.2.1
-        csiNode:
-          image:
-            repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
+          vsphereSyncer:
+            repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
             tag: v2.7.0
-            nodeDriverRegistrar:
-              repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
-              tag: v2.5.1
-            livenessProbe:
-              repository: rancher/mirrored-sig-storage-livenessprobe
-              tag: v2.7.0
-
+          csiProvisioner:
+            repository: rancher/mirrored-sig-storage-csi-provisioner
+            tag: v3.2.1
+      csiNode:
+        image:
+          repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
+          tag: v2.7.0
+          nodeDriverRegistrar:
+            repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
+            tag: v2.5.1
+          livenessProbe:
+            repository: rancher/mirrored-sig-storage-livenessprobe
+            tag: v2.7.0
   - constraint: ">= 1.24 < 1.25"
     values:
       csiController:

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -187,7 +187,7 @@ versionOverrides:
       csiController:
         image:
           repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
-          tag: v2.5.3
+          tag: v2.5.4
           csiAttacher:
             repository: rancher/mirrored-sig-storage-csi-attacher
             tag: v3.4.0
@@ -206,7 +206,7 @@ versionOverrides:
       csiNode:
         image:
           repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
-          tag: v2.5.3
+          tag: v2.5.4
           nodeDriverRegistrar:
             repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
             tag: v2.5.0

--- a/tests/unit/cpi_template_test.go
+++ b/tests/unit/cpi_template_test.go
@@ -36,7 +36,7 @@ func TestCPITemplateRenderedDaemonset(t *testing.T) {
 				namespace:     "cpitest-" + strings.ToLower(random.UniqueId()),
 				releaseName:   "cpitest-" + strings.ToLower(random.UniqueId()),
 				chartRelPath:  cpiChart,
-				expectedImage: "rancher/mirrored-cloud-provider-vsphere-cpi-release-manager:v1.24.1",
+				expectedImage: "rancher/mirrored-cloud-provider-vsphere-cpi-release-manager:v1.25.0",
 			},
 		},
 		{
@@ -47,7 +47,7 @@ func TestCPITemplateRenderedDaemonset(t *testing.T) {
 				namespace:     "cpitest-" + strings.ToLower(random.UniqueId()),
 				releaseName:   "cpitest-" + strings.ToLower(random.UniqueId()),
 				chartRelPath:  cpiChart,
-				expectedImage: "rancher/mirrored-cloud-provider-vsphere-cpi-release-manager:v1.24.1",
+				expectedImage: "rancher/mirrored-cloud-provider-vsphere-cpi-release-manager:v1.24.2",
 			},
 		},
 		{

--- a/tests/unit/csi_template_test.go
+++ b/tests/unit/csi_template_test.go
@@ -29,6 +29,40 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 		args args
 	}{
 		{
+			name: "Kubernetes 1.25 Linux Only",
+			args: args{
+				values:         map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:    "1.25",
+				namespace:      "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:    "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:   csiChart,
+				windowsEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.1",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.7.0",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.25 Linux and Windows",
+			args: args{
+				values: map[string]string{
+					"vCenter.clusterId":         random.UniqueId(),
+					"csiWindowsSupport:enabled": "true",
+				},
+				kubeVersion:  "1.25",
+				namespace:    "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:  "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath: csiChart,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.1",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.7.0",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
+				},
+			},
+		},
+		{
 			name: "Kubernetes 1.24 Linux Only",
 			args: args{
 				values:         map[string]string{"vCenter.clusterId": random.UniqueId()},
@@ -39,7 +73,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				windowsEnabled: false,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.1",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.6.1",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.6.2",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
 				},
 			},
@@ -57,7 +91,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				chartRelPath: csiChart,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.1",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.6.1",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.6.2",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
 				},
 			},
@@ -73,7 +107,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				windowsEnabled: false,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.3",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.4",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.6.0",
 				},
 			},
@@ -91,7 +125,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				chartRelPath: csiChart,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.3",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.4",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.6.0",
 				},
 			},
@@ -107,7 +141,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				windowsEnabled: false,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.3",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.4",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.6.0",
 				},
 			},
@@ -125,7 +159,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				chartRelPath: csiChart,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.3",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.4",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.6.0",
 				},
 			},
@@ -141,7 +175,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				windowsEnabled: false,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.3",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.4",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.6.0",
 				},
 			},
@@ -159,7 +193,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				chartRelPath: csiChart,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.3",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.4",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.6.0",
 				},
 			},
@@ -193,7 +227,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				chartRelPath: csiChart,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.3",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.4",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.6.0",
 				},
 			},
@@ -258,6 +292,46 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 		args args
 	}{
 		{
+			name: "Kubernetes 1.25 with CSI Resizer Enabled",
+			args: args{
+				values: map[string]string{
+					"vCenter.clusterId":                random.UniqueId(),
+					"csiController.csiResizer.enabled": "true",
+				},
+				kubeVersion:       "1.25",
+				namespace:         "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:       "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:      csiChart,
+				csiResizerEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-attacher:v3.4.0",
+					"rancher/mirrored-sig-storage-csi-resizer:v1.4.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.7.0",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.7.0",
+					"rancher/mirrored-sig-storage-csi-provisioner:v3.2.1",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.25",
+			args: args{
+				values:            map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:       "1.25",
+				namespace:         "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:       "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:      csiChart,
+				csiResizerEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-attacher:v3.4.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.7.0",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.7.0",
+					"rancher/mirrored-sig-storage-csi-provisioner:v3.2.1",
+				},
+			},
+		},
+		{
 			name: "Kubernetes 1.24 with CSI Resizer Enabled",
 			args: args{
 				values: map[string]string{
@@ -272,9 +346,9 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-attacher:v3.4.0",
 					"rancher/mirrored-sig-storage-csi-resizer:v1.4.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.6.1",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.6.2",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.6.1",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.6.2",
 					"rancher/mirrored-sig-storage-csi-provisioner:v3.2.1",
 				},
 			},
@@ -290,9 +364,9 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				csiResizerEnabled: false,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-attacher:v3.4.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.6.1",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.6.2",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.6.1",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.6.2",
 					"rancher/mirrored-sig-storage-csi-provisioner:v3.2.1",
 				},
 			},
@@ -308,9 +382,9 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				csiResizerEnabled: false,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-attacher:v3.4.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.3",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.4",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.6.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.5.3",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.5.4",
 					"rancher/mirrored-sig-storage-csi-provisioner:v3.1.0",
 				},
 			},
@@ -326,9 +400,9 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				csiResizerEnabled: false,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-attacher:v3.4.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.3",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.4",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.6.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.5.3",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.5.4",
 					"rancher/mirrored-sig-storage-csi-provisioner:v3.1.0",
 				},
 			},
@@ -344,9 +418,9 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				csiResizerEnabled: false,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-attacher:v3.4.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.3",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.4",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.6.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.5.3",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.5.4",
 					"rancher/mirrored-sig-storage-csi-provisioner:v3.1.0",
 				},
 			},
@@ -384,9 +458,9 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-attacher:v3.4.0",
 					"rancher/mirrored-sig-storage-csi-resizer:v1.4.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.3",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.5.4",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.6.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.5.3",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.5.4",
 					"rancher/mirrored-sig-storage-csi-provisioner:v3.1.0",
 				},
 			},


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.
- [x] Changes to scripting or CI config have been tested to the best of your ability - NA

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->

Image version update
* CPI 1.24.1 -> 1.24.2, 1.25.0
* CSI 2.6.1 -> 2.6.2, 2.7.0 

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

https://github.com/rancher/rancher/issues/38188

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, please post an announcement in the following channels:

* #discuss-rancher-feature-charts
* #discuss-rancher-feature-vsphere
* #discuss-rancher-k3s-rke2