### PR TITLE
Bump chart version/appVersion

### DIFF
--- a/charts/rancher-vsphere-cpi/Chart.yaml
+++ b/charts/rancher-vsphere-cpi/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
   catalog.cattle.io/rancher-version: '>= 2.6.0-0'
   catalog.cattle.io/release-name: vsphere-cpi
 apiVersion: v1
-appVersion: 1.2.4
+appVersion: 1.4.1
 description: vSphere Cloud Provider Interface (CPI)
 icon: https://charts.rancher.io/assets/logos/vsphere-cpi.svg
 keywords:
@@ -19,4 +19,4 @@ maintainers:
 name: rancher-vsphere-cpi
 sources:
 - https://github.com/kubernetes/cloud-provider-vsphere
-version: 1.4.0
+version: 1.4.1

--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
   catalog.cattle.io/rancher-version: '>= 2.6.0-0'
   catalog.cattle.io/release-name: vsphere-csi
 apiVersion: v1
-appVersion: 2.6.1-rancher1
+appVersion: 2.6.2-rancher1
 description: vSphere Cloud Storage Interface (CSI)
 icon: https://charts.rancher.io/assets/logos/vsphere-csi.svg
 keywords:
@@ -19,4 +19,4 @@ maintainers:
 name: rancher-vsphere-csi
 sources:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 2.6.1-rancher1
+version: 2.6.2-rancher1


### PR DESCRIPTION
* Bump vsphere-csi to 2.6.2 to sync with release driver version
* Bump vsphere-cpi to 1.4.1; this version appears to be unrelated to any of the actual component versions and unique to our packaging.

- [x] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

fix chart versions

#### Linked Issues ####

#35 made changes to the charts without changing the chart version or appVersion.

#### Additional Notes ####


#### After the PR is merged ####

Once the PR is merged, typically upon a new release, please post an announcement in the following channels:

* #discuss-rancher-feature-charts
* #discuss-rancher-feature-vsphere
* #discuss-rancher-k3s-rke2