### PR TITLE
Update vSphere PR checklist and process docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,4 +20,4 @@
 
 #### After the PR is merged ####
 
-Once the PR is merged, typically upon a new release, the necessary teams will be notified Slack hook to perform the rancher/rke2-charts and RKE2 changes. Any developer working on this issue is not responsible for updating rancher/rke2-charts or RKE2.
+Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 #### Pull Request Checklist ####
 
 - [ ] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
+- [ ] Chart version has been incremented (if necessary)
 - [ ] That helm lint and pack run successfully on the chart.
 - [ ] Deployment of the chart has been tested and verified that it functions as expected.
 - [ ] Changes to scripting or CI config have been tested to the best of your ability
@@ -19,8 +20,4 @@
 
 #### After the PR is merged ####
 
-Once the PR is merged, typically upon a new release, please post an announcement in the following channels:
-
-* #discuss-rancher-feature-charts
-* #discuss-rancher-feature-vsphere
-* #discuss-rancher-k3s-rke2
+Once the PR is merged, typically upon a new release, the necessary teams will be notified Slack hook to perform the rancher/rke2-charts and RKE2 changes. Any developer working on this issue is not responsible for updating rancher/rke2-charts or RKE2.

--- a/DEVELOPING.MD
+++ b/DEVELOPING.MD
@@ -161,3 +161,17 @@ Once the RKE2-Charts PR has been merged, a member from the RKE2 team can update 
 ### Step 7: Create Rancher Charts PR
 
 The last step is to pull the vSphere charts into the Rancher charts repository. The process is well documented, so follow the instructions listed in that repository for the workflow. [Here](https://github.com/rancher/charts/pull/1898) is an example PR.
+
+If there is an existing patch for CSI/CPI in charts upstream, you may have to remove the generated-changes folder, reapply your changes, manually apply the upstream patch, then regenerate the patch. [Here](https://github.com/rancher/charts/pull/2204) is an example PR. Team 3 is working on a 3-way rebase script that may be available soon.
+
+Here are walkthrough steps,
+
+* Delete the generated-changes dir
+* Run `make prepare`
+* Apply your changes: bump chart versions and `release.yaml` to track the new versions. Manually reapply any patches from charts upstream
+* Run `make patch && make clean`
+* Run `git commit -am <message>`
+* Run `make charts`
+* Run `git commit -m "Make charts"`
+* Check the generated CSI/CPI chart files against vsphere-charts upstream
+* Run `make validate` (I always do this to confirm the PR build will pass before pushing!)

--- a/DEVELOPING.MD
+++ b/DEVELOPING.MD
@@ -1,18 +1,18 @@
 # Developer Guide for vSphere Charts for Rancher
 
-This guide is going to highlight the steps that are required to develop and maintian the vSphere charts for [CPI](https://github.com/kubernetes/cloud-provider-vsphere) and [CSI](https://github.com/kubernetes-sigs/vsphere-csi-driver) for Rancher. Upstream is only releasing manifests at this point and they do that in version specific branches. We use these upstream manifests to create the charts that we use. This makes the process a touch more complex as each manifest needs compared to the helm chart template to make the appropriate changes. Since we mirror images into our own container registry, we also have to check the manifests every time a release happens to gather the correct image versions to keep our registry synced. Once the charts and images have been updated, we then need to ensure that the charts are updated in both [RKE2-Charts](https://github.com/rancher/rke2-charts), [RKE2](https://github.com/rancher/rke2), and [Rancher Charts](https://github.com/rancher/charts).  
+This guide is going to highlight the steps that are required to develop and maintian the vSphere charts for [CPI](https://github.com/kubernetes/cloud-provider-vsphere) and [CSI](https://github.com/kubernetes-sigs/vsphere-csi-driver) for Rancher. Upstream is only releasing manifests at this point and they do that in version specific branches. We use these upstream manifests to create the charts that we use. This makes the process a touch more complex as each manifest needs to be compared to the helm chart template to make the appropriate changes. Since we mirror images into our own container registry, we also have to check the manifests every time a release happens to gather the correct image versions to keep our registry synced. Once the charts and images have been updated, we then need to ensure that the charts are updated in [Rancher Charts](https://github.com/rancher/charts), [RKE2-Charts](https://github.com/rancher/rke2-charts), and [RKE2](https://github.com/rancher/rke2).  
 
-#### You may be asking why both RKE2 and Rancher charts? 
+#### You may be asking why both Rancher charts and RKE2? 
 
-RKE2 embeds the charts that it ships with each version of RKE2 that is released. This means that RKE2 always uses it's own version of the vSphere charts regardless if deployed standalone or through Rancher. The charts being deployed are determined by the selected cloud provider when provisioning. The Rancher charts shouldn't be consumed for RKE2 and currently exist for use with non-RKE2 clusters that are provisioned in Rancher, primarily RKE1. 
+RKE2 embeds the charts that it ships with each version of RKE2 that is released. This means that RKE2 always uses its own version of the vSphere charts regardless if deployed standalone or through Rancher. The charts being deployed are determined by the selected cloud provider when provisioning. Rancher charts shouldn't be consumed for RKE2 and currently exist for use with non-RKE2 clusters that are provisioned in Rancher, primarily RKE1. 
 
-#### Upstream releases 
+#### Upstream Releases 
 
-Upstream releases are not immediate when a new version of Kubernetes is released. This means that the charts typically lag behind Kubernets verison by at least a month if not longer. This means that often that users can't upgrade clusters immediately or deploy the newest version that is released in RKE2 or Rancher with full support.
+Upstream releases are not immediate when a new version of Kubernetes is released. This means that the charts typically lag behind the Kubernetes version by at least a month if not longer. This often means that users can't upgrade clusters immediately or deploy the newest version that is released in RKE2 or Rancher with full support.
 
 #### Cloud Provider Skew Policy
 
-Cloud providers, cloud controller manager, in Kubernetes support a [skew policy](https://kubernetes.io/releases/version-skew-policy/#kube-controller-manager-kube-scheduler-and-cloud-controller-manager). This allows us to use one minor version older of a CPI on Kubernetes cluster. The primary purpose is to allow upgrades, yet it also gives us the ability to deploy an older CPI before the official one has been released for the new version of Kubernetes. CSI doesn't have these gaurantees explicitly defined and so don't assume with CSI that it will work.
+Cloud providers, cloud controller manager, in Kubernetes support a [skew policy](https://kubernetes.io/releases/version-skew-policy/#kube-controller-manager-kube-scheduler-and-cloud-controller-manager). This allows us to use one minor version older of a CPI on Kubernetes cluster. The primary purpose is to allow upgrades, yet also gives us the ability to deploy an older CPI before the official one has been released for the new version of Kubernetes.
 
 ## Chart Design
 
@@ -27,6 +27,7 @@ Features and upstream releases are the primary reason to be working in this repo
 * Check the upstream manifests for changes and new image versions
 * Update the [image-mirror](https://github.com/rancher/image-mirror) repository for new images
 * Update the charts with the new images and manifest changes
+* Update the chart versions (if necessary)
 * Locally compile and deploy to a Kubernetes cluster to ensure that the chart functions
 * Check with RKE2 on the next release cycle and plan out PRs for getting these changes included by the target release date.
 * Update Rancher Charts with the new versions
@@ -46,18 +47,18 @@ Before getting started, it is suggested to create an issue in the Rancher/Ranche
 
 - [ ] Update Image-mirror repo
 - [ ] Update manifests in rancher/vsphere-charts
-- [ ] Notify about chart "release"
+- [ ] Notify about chart "release" (reference @brandond @cwayne18 and @rancher-max in team-release-rancher-bits that the new chart version is available)
 - [ ] Update chart in rancher/charts
-- [ ] Update chart in rancher/rke2-charts
-- [ ] Updated RKE2 to consume new chart
+- [ ] Update chart in rancher/rke2-charts (RKE2 team)
+- [ ] Updated RKE2 to consume new chart (RKE2 team)
 ```
 
-Then for every PR, link back to this issue so everything can be tracked. When you get to RKE2, you will need to create a separate issue in the RKE2 repository in addition to the Rancher one. 
+For every PR, link back to this issue so everything can be tracked. Whoever does the RKE2 updates will need to create a separate issue in the RKE2 repository in addition to the Rancher one. 
 
 Here are some examples:
 
-* Rancher Issue: https://github.com/rancher/rancher/issues/38188
-* RKE2 issue: https://github.com/rancher/rke2/issues/2867
+* [Rancher Issue](https://github.com/rancher/rancher/issues/38188)
+* [RKE2 issue](https://github.com/rancher/rke2/issues/2867)
 
 ### Step 1: Checking upstream manifests
 
@@ -65,9 +66,9 @@ There are two goals when checking upstream manifests. The first goal is to check
 
 If you find that image versions have been updated, then you will need to make a pull request to the [image-mirror](https://github.com/rancher/image-mirror) repository first before proceeding. [Here](https://github.com/rancher/image-mirror/pull/261) is an example PR and follow the requirements outlined in the PR template for those changes. After the images have been checked and image-mirror updated with any new images or image versions, then proceed to check check the manifests.
 
-Checking the manifests is best done by cloning down the branch for the version that you want to compare with the helm templates. Then using a diff tool like, Kdiff/Meld/WinMerge, compare each manifest directory with the helm chart directory. Look at the diffs and decide if that diff is brining in a modification or addition that needs to be added to the charts in this repository. If you determine the diff needs brought over, then do so. 
+Checking the manifests is best done by doing a tag compare in each upstream chart. Compare the chart tag, that the rancher vsphere chart is based off of, with the latest tag in upstream. This compares the manifest directories. If there is a change that needs to be added to charts in this repository, bring it in. [Here](https://github.com/kubernetes/cloud-provider-vsphere/compare/v1.25.0...v1.24.2) is an example.
 
-Finally, make sure that the unit tests for each chart has test cases added to existing tests, test are updated, or new tests are added based on the set of changes.
+Finally, make sure that the unit tests for each chart have been updated, or new tests or test cases are added based on the set of changes. Increment the chart version, if necessary.
 
 ### Step 2: Compile and check locally
 
@@ -108,32 +109,49 @@ PASS
 ok  	github.com/rancher/vsphere-charts/tests/unit	(cached)
 ```
 
-If everything passes here then it's time to test deployment to a cluster, if something errors, then please correct it and ensure all checks pass.
+If everything passes here then it's time to test deployment to a cluster. If something errors, then please correct it and ensure all checks pass.
 
-# Step 3: Deploying the chart
+### Step 3: Deploying the chart
 
-At this stage, it's now safe to actually test the charts on a real cluster. Typically, a RKE1 cluster is deployed on vSphere using Rancher. Then the kubeconfig is downloaded from the cluster and used to deploy the local chart to the cluster using helm. Here is an example. Make sure to supply the vSphere configuration required.
+At this stage, it's now safe to test the charts on a real cluster. Typically, a RKE1 cluster is deployed on vSphere using Rancher. Then the kubeconfig is downloaded from the cluster and used to deploy the local chart to the cluster using helm. Here is an example.
 
 ```
-$ helm install -f vsphere-test-config.yaml --kubeconfig <path to kube config> cpi ./charts/rancher-vsphere-cpi 
+$ helm install -f values.yaml --kubeconfig <path to kube config> csi ./charts/rancher-vsphere-csi 
+```
+
+```
+$ helm install -f values.yaml --namespace --kube-system --kubeconfig <path to kube config> cpi ./charts/rancher-vsphere-cpi
+```
+
+The CPI chart **must** be installed in the `kube-system` namespace.
+
+Make sure to supply the vSphere configuration required. Your `values.yaml` is the values that get passed to helm on a chart deploy. Here's an example.
+
+```
+vCenter:
+  host: "engqa-7-wrangler.fremont.rancherlabs.com"
+  port: 443
+  insecureFlag: true
+  clusterId: "test-cluster-id"
+  datacenters: "ENGQA-7-DC"
+  username: "<add username>>"
+  password: "<add password>"
 ```
 
 Ensure that all pods for both the CPI and CSI charts come up without errors. Make sure that the provider gets set on each node to be vSphere. 
 
-# Step 4: PR to Rancher vSphere Charts Repository
+### Step 4: PR to Rancher vSphere Charts Repository
 
-You are now ready to create your PR to the vSphere charts repository. Fill out the PR template and request reviews. Once the PR has been approved and passed the Drone run, you can merge. 
+You are now ready to submit a PR to the vSphere charts repository. Fill out the PR template and request reviews. Once the PR has been approved and passed the Drone run, you can merge. [Here](https://github.com/rancher/vsphere-charts/pull/35) is an example PR. 
 
-# Step 5: Create RKE2-Charts PR
+### Step 5: Create RKE2-Charts PR
 
-Now you can pull the chart into the RKE2-Charts repository. [Here](https://github.com/rancher/rke2-charts/pull/250) is an exapmle PR. 
+A member from the RKE2 team can now pull the chart into the RKE2-Charts repository. [Here](https://github.com/rancher/rke2-charts/pull/250) is an example PR. 
 
-# Step 6: Create RKE2 PR
+### Step 6: Create RKE2 PR
 
-Once the RKE2-Charts PR has been merged, you can update RKE2. You will need to coordinate with the RKE2 before submitting the PR. This step will also require that you backport the PR to each branch of the still supported versions of RKE2, again coordinate with the RKE2 team before proceeding.
+Once the RKE2-Charts PR has been merged, a member from the RKE2 team can update the chart in the RKE2 repository. This step requires a backport PR to each branch of the still supported versions of RKE2. [Here](https://github.com/rancher/rke2/pull/2868) is an example PR and an [example](https://github.com/rancher/rke2/pull/2870) backport.
 
-[Here](https://github.com/rancher/rke2/pull/2868) is an example PR and an [example](https://github.com/rancher/rke2/pull/2870) backport.
+### Step 7: Create Rancher Charts PR
 
-# Step 7: Create Rancher Charts PR
-
-This is the last step of the process, which is to now pull the charts into the Rancher charts repository. The process for that repository is well documented, just follow the instructions listed in that repository for the workflow. [Here](https://github.com/rancher/charts/pull/1898) is an example PR.
+The last step is to pull the vSphere charts into the Rancher charts repository. The process is well documented, so follow the instructions listed in that repository for the workflow. [Here](https://github.com/rancher/charts/pull/1898) is an example PR.

--- a/DEVELOPING.MD
+++ b/DEVELOPING.MD
@@ -47,7 +47,7 @@ Before getting started, it is suggested to create an issue in the Rancher/Ranche
 
 - [ ] Update Image-mirror repo
 - [ ] Update manifests in rancher/vsphere-charts
-- [ ] Notify about chart "release" (reference @brandond @cwayne18 and @rancher-max in team-release-rancher-bits that the new chart version is available)
+- [ ] Verify Slack hook notified about chart "release" in relevant channels
 - [ ] Update chart in rancher/charts
 - [ ] Update chart in rancher/rke2-charts (RKE2 team)
 - [ ] Updated RKE2 to consume new chart (RKE2 team)
@@ -129,13 +129,13 @@ Make sure to supply the vSphere configuration required. Your `values.yaml` is th
 
 ```
 vCenter:
-  host: "engqa-7-wrangler.fremont.rancherlabs.com"
-  port: 443
+  host: <host>
+  port: <port>
   insecureFlag: true
   clusterId: "test-cluster-id"
-  datacenters: "ENGQA-7-DC"
-  username: "<add username>>"
-  password: "<add password>"
+  datacenters: <datacenter>
+  username: <username>
+  password: <password>
 ```
 
 Ensure that all pods for both the CPI and CSI charts come up without errors. Make sure that the provider gets set on each node to be vSphere. 

--- a/DEVELOPING.MD
+++ b/DEVELOPING.MD
@@ -28,6 +28,7 @@ Features and upstream releases are the primary reason to be working in this repo
 * Update the [image-mirror](https://github.com/rancher/image-mirror) repository for new images
 * Update the charts with the new images and manifest changes
 * Update the chart versions (if necessary)
+* Update the chart tests
 * Locally compile and deploy to a Kubernetes cluster to ensure that the chart functions
 * Check with RKE2 on the next release cycle and plan out PRs for getting these changes included by the target release date.
 * Update Rancher Charts with the new versions
@@ -68,7 +69,12 @@ If you find that image versions have been updated, then you will need to make a 
 
 Checking the manifests is best done by doing a tag compare in each upstream chart. Compare the chart tag, that the rancher vsphere chart is based off of, with the latest tag in upstream. This compares the manifest directories. If there is a change that needs to be added to charts in this repository, bring it in. [Here](https://github.com/kubernetes/cloud-provider-vsphere/compare/v1.25.0...v1.24.2) is an example.
 
-Finally, make sure that the unit tests for each chart have been updated, or new tests or test cases are added based on the set of changes. Increment the chart version, if necessary.
+Make sure that the unit tests for each chart have been updated, or new tests or test cases are added based on the set of manifest changes.
+
+Finally increment the chart version, if necessary. We need to update the chart version anytime that a new tag of CSI/CPI is released and we update to that version of upstream.
+
+CPI and CSI versioning is different because CSI tracks the version from upstream so it needs a `-rancher1` for when we need to do a Rancher specific patch, whereas CPI doesn’t track the same version from upstream (they have multiple CPIs based on Kubernetes version. Our CPI chart is based on all of them together). We use our own versioning so we can bump the patch for Rancher specific versions. [Here](https://github.com/rancher/vsphere-charts/pull/36/commits/5bb4f6a042dc31ace66522fe670a72930d5d3e63) is an example.
+
 
 ### Step 2: Compile and check locally
 


### PR DESCRIPTION
#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->

PR template
- [x] Update checklist to include a point to update the chart version.
- [x] Remove slack channels

DEVELOPMENT.md
- [x] spelling errors
- [x] how to compare upstream tags
- [x] example values.yaml for deploying CSI/CPI chart
- [x] CPI chart **must** be deployed with `--namespace kube-system` according to [the docs](https://github.com/phillipsj/vsphere-charts/blob/c1de480374f993b2299908d05f15d3f4585fceac/charts/rancher-vsphere-cpi/README.md)
- [x] example rancher/charts PR
- [x] RKE2 team is responsible for the rancher/rke2-charts and RKE2 updates

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified Slack hook to perform the rancher/rke2-charts and RKE2 changes. Any developer working on this issue is not responsible for updating rancher/rke2-charts or RKE2.