### PR TITLE
Bump CPI image versions to v1.24.3, v1.23.3, v1.22.7

### DIFF
--- a/charts/rancher-vsphere-cpi/values.yaml
+++ b/charts/rancher-vsphere-cpi/values.yaml
@@ -36,17 +36,17 @@ versionOverrides:
     values:
       cloudControllerManager:
         repository: rancher/mirrored-cloud-provider-vsphere-cpi-release-manager
-        tag: v1.24.2
+        tag: v1.24.3
   - constraint: ">= 1.23 < 1.24"
     values:
       cloudControllerManager:
         repository: rancher/mirrored-cloud-provider-vsphere-cpi-release-manager
-        tag: v1.23.1
+        tag: v1.23.3
   - constraint: "~ 1.22"
     values:
       cloudControllerManager:
         repository: rancher/mirrored-cloud-provider-vsphere-cpi-release-manager
-        tag: v1.22.6
+        tag: v1.22.7
   - constraint: "~ 1.21"
     values:
       cloudControllerManager:
@@ -70,7 +70,7 @@ versionOverrides:
 
 cloudControllerManager:
   repository: rancher/mirrored-cloud-provider-vsphere-cpi-release-manager
-  tag: v1.22.6
+  tag: v1.22.7
   nodeSelector: {}
   tolerations: []
   rbac:

--- a/tests/unit/cpi_template_test.go
+++ b/tests/unit/cpi_template_test.go
@@ -47,7 +47,7 @@ func TestCPITemplateRenderedDaemonset(t *testing.T) {
 				namespace:     "cpitest-" + strings.ToLower(random.UniqueId()),
 				releaseName:   "cpitest-" + strings.ToLower(random.UniqueId()),
 				chartRelPath:  cpiChart,
-				expectedImage: "rancher/mirrored-cloud-provider-vsphere-cpi-release-manager:v1.24.2",
+				expectedImage: "rancher/mirrored-cloud-provider-vsphere-cpi-release-manager:v1.24.3",
 			},
 		},
 		{
@@ -58,7 +58,7 @@ func TestCPITemplateRenderedDaemonset(t *testing.T) {
 				namespace:     "cpitest-" + strings.ToLower(random.UniqueId()),
 				releaseName:   "cpitest-" + strings.ToLower(random.UniqueId()),
 				chartRelPath:  cpiChart,
-				expectedImage: "rancher/mirrored-cloud-provider-vsphere-cpi-release-manager:v1.23.1",
+				expectedImage: "rancher/mirrored-cloud-provider-vsphere-cpi-release-manager:v1.23.3",
 			},
 		},
 		{
@@ -69,7 +69,7 @@ func TestCPITemplateRenderedDaemonset(t *testing.T) {
 				namespace:     "cpitest-" + strings.ToLower(random.UniqueId()),
 				releaseName:   "cpitest-" + strings.ToLower(random.UniqueId()),
 				chartRelPath:  cpiChart,
-				expectedImage: "rancher/mirrored-cloud-provider-vsphere-cpi-release-manager:v1.22.6",
+				expectedImage: "rancher/mirrored-cloud-provider-vsphere-cpi-release-manager:v1.22.7",
 			},
 		},
 		{


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] Chart version has been incremented (if necessary)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected. **(on vSphere RKE1 cluster)**
- [x] Changes to scripting or CI config have been tested to the best of your ability **NA**

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->

Bump CPI images to v1.24.3, v1.23.3, and v1.22.7 in the chart and unit tests.

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

https://github.com/rancher/rancher/issues/39968

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.