### PR TITLE
Add topology plugin value for rancher-vsphere-csi, update readme

### DIFF
--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
   catalog.cattle.io/rancher-version: '>= 2.6.0-0'
   catalog.cattle.io/release-name: vsphere-csi
 apiVersion: v1
-appVersion: 2.6.2-rancher1
+appVersion: 2.6.2-rancher2
 description: vSphere Cloud Storage Interface (CSI)
 icon: https://charts.rancher.io/assets/logos/vsphere-csi.svg
 keywords:
@@ -19,4 +19,4 @@ maintainers:
 name: rancher-vsphere-csi
 sources:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 2.6.2-rancher1
+version: 2.6.2-rancher2

--- a/charts/rancher-vsphere-csi/README.md
+++ b/charts/rancher-vsphere-csi/README.md
@@ -71,3 +71,14 @@ More information on managing Secrets using kubectl [here](https://kubernetes.io/
 ## Migration
 
 The CSI migration feature is only available for vSphere 7.0 U1.
+
+## vSphere CSI with Topology
+
+When deploying to a vSphere environment using zoning, the topology plugin can be enabled for the CSI to make intelligent volume provisioning decisions. More information on vSphere zoning and prerequisites for the CSI toplogy plugin can be found [here](https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/2.0/vmware-vsphere-csp-getting-started/GUID-162E7582-723B-4A0F-A937-3ACE82EAFD31.html#guidelines-and-best-practices-for-deployment-with-topology-0).
+
+To enable the topology plugin, adjust the values for the chart as follows:
+
+```yaml
+topology:
+  enabled: true
+```

--- a/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
+++ b/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
@@ -205,9 +205,11 @@ spec:
             - "--kube-api-burst=100"
             - "--leader-election"
             - "--default-fstype=ext4"
+            {{- if .Values.topology.enabled }}
             # needed only for topology aware setup
-            #- "--feature-gates=Topology=true"
-            #- "--strict-topology"
+            - "--feature-gates=Topology=true"
+            - "--strict-topology"
+            {{- end }}
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -84,6 +84,8 @@ pvToBackingdiskobjectidMapping:
   enabled: false
 cnsmgrSuspendCreateVolume:
   enabled: false
+topology:
+  enabled: false
 topologyPreferentialDatastores:
   enabled: false
 maxPvscsiTargetsPerVm:


### PR DESCRIPTION
#### Pull Request Checklist ####

- N/A - Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] Chart version has been incremented (if necessary)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.
- N/A Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Add helm value to allow the CSI topology feature:
```yaml
topology:
  enabled: true
```

#### Linked Issues ####

https://github.com/rancher/rancher/issues/40727