### PR TITLE
Fix vSphere CPI label propogation and remove sensitive fields

### DIFF
--- a/charts/rancher-vsphere-cpi/Chart.yaml
+++ b/charts/rancher-vsphere-cpi/Chart.yaml
@@ -19,4 +19,4 @@ maintainers:
 name: rancher-vsphere-cpi
 sources:
 - https://github.com/kubernetes/cloud-provider-vsphere
-version: 1.4.1
+version: 1.4.2

--- a/charts/rancher-vsphere-cpi/questions.yaml
+++ b/charts/rancher-vsphere-cpi/questions.yaml
@@ -45,17 +45,17 @@ questions:
     label: Define vSphere Tags
     description: "vSphere Tags used to determine the zone and region of a Kubernetes node. This labels will be propagated to NodeLabels"
     type: boolean
-    default: true
+    default: false
     required: true
     group: Configuration
     show_subquestion_if: true
     subquestions:
-      - variable: labels.region
+      - variable: vCenter.labels.region
         label: Region
         description: vSphere tag which will used to define regions. e.g. eu-central
         type: string
         group: Configuration
-      - variable: labels.zone
+      - variable: vCenter.labels.zone
         label: Zone
         description: vSphere tag which will used to define availability zones
         type: string

--- a/charts/rancher-vsphere-cpi/templates/configmap.yaml
+++ b/charts/rancher-vsphere-cpi/templates/configmap.yaml
@@ -16,16 +16,17 @@ data:
       port: {{ .port }}
       insecureFlag: {{ .insecureFlag }}
 
+    # vcenter section
     vcenter:
       {{ .host | quote }}:
         server: {{ .host | quote }}
-        user: {{ .username }}
-        password: {{ .password }}
         datacenters:
           - {{ .datacenters | quote }}
     {{- if .labels.generate }}
+
+    # labels for regions and zones
     labels:
-      region: {{ .labels.region }}
-      zone: {{ .labels.zone }}
+      region: {{ .labels.region | quote }}
+      zone: {{ .labels.zone | quote }}
     {{- end }}
     {{- end }}

--- a/charts/rancher-vsphere-cpi/values.yaml
+++ b/charts/rancher-vsphere-cpi/values.yaml
@@ -13,6 +13,7 @@ vCenter:
   labels:
     region: "k8s-region"
     zone: "k8s-zone"
+    generate: false
 
 # A list of Semver constraint strings (defined by https://github.com/Masterminds/semver) and values.yaml overrides.
 #


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] Chart version has been incremented (if necessary)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Type of Change ####

<!-- New image, version bump. script update, etc etc -->

The following changes have been implemented on the vSphere CPI chart

* Remove user/password from configmap (security fix)
* Fix label propagation of region/zone to `NodeLabels` in questions.yaml. Questions.yaml is what generates chart options in the rancher UI so this change ensures that the values that the user inputs for region/zone if they enable `vSphere Tags` will be set correctly in the chart.
* Fix label generation to be `default: false` because not every user will have zoning setup on the backend vSphere infra or want workloads deployed in a specific location.
* Add `generate` field to `values.yaml` so that if a user deploys the chart using Helm they can specify `generate: true` so their input values for zone/region will show up in the configmap. `credentialsSecret` has [this option](https://github.com/rancher/vsphere-charts/blob/main/charts/rancher-vsphere-cpi/values.yaml#L8-L10) and I believe it was just missing from labels.

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.

#### Testing

The CPI chart has been tested to make sure it successfully deploys and removes taints from downstream nodes. With the following `values.yaml,` the config map looks like below.

<details>

<summary>values.yaml</summary>

```
vCenter:
  host: "<host>"
  port: <port>
  insecureFlag: true
  clusterId: "ablender-test-cluster-id"
  datacenters: "<datacenter>"
  username: "<username>"
  password: "<password>"

  labels:
    generate: true
    region: "test-region"
    zone: "test-zone"
```

</details>

<details>

<summary>What the CPI configmap looks like now</summary>

```
# Global properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.

global:
  secretName: "vsphere-cpi-creds"
  secretNamespace: "kube-system"
  port: <port>
  insecureFlag: true

# vcenter section
vcenter:
  "<server name>":
    server: "<server name>"
    datacenters:
      - "<datacenter>"


# labels for regions and zones
labels:
  region: "test-region"
  zone: "test-zone"
```

</details>
