### PR TITLE
Fix affinities

### DIFF
--- a/charts/rancher-vsphere-cpi/Chart.yaml
+++ b/charts/rancher-vsphere-cpi/Chart.yaml
@@ -19,4 +19,4 @@ maintainers:
 name: rancher-vsphere-cpi
 sources:
 - https://github.com/kubernetes/cloud-provider-vsphere
-version: 1.4.2
+version: 1.4.3

--- a/charts/rancher-vsphere-cpi/templates/daemonset.yaml
+++ b/charts/rancher-vsphere-cpi/templates/daemonset.yaml
@@ -38,13 +38,16 @@ spec:
                 operator: In
                 values:
                 - "true"
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - "windows"
             - matchExpressions:
               # RKE2 node selector label
               - key: node-role.kubernetes.io/control-plane
                 operator: In
                 values:
                 - "true"
-            - matchExpressions:
               - key: kubernetes.io/os
                 operator: NotIn
                 values:

--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -19,4 +19,4 @@ maintainers:
 name: rancher-vsphere-csi
 sources:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 2.6.2-rancher2
+version: 2.6.2-rancher3

--- a/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
+++ b/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
@@ -37,13 +37,17 @@ spec:
                 operator: In
                 values:
                 - "true"
+              # Rancher node selector label
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - "windows"
             - matchExpressions:
               # RKE2 node selector label
               - key: node-role.kubernetes.io/control-plane
                 operator: In
                 values:
                 - "true"
-            - matchExpressions:
               # Rancher node selector label
               - key: kubernetes.io/os
                 operator: NotIn


### PR DESCRIPTION
The controllers should only be scheduled onto control plane nodes.

Needed for https://github.com/rancher/vsphere-charts/issues/46

#### Pull Request Checklist ####

- [x] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] Chart version has been incremented (if necessary)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####
Node affinity for CPI/CSI controllers changed to only schedule them to control plane nodes. Currently the charts allow scheduling the controller pods to any non-Windows node.

#### Linked Issues ####
#46 

#### Additional Notes ####
N/A

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.