### PR TITLE
Added prefix path to liveness probe

### DIFF
--- a/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
@@ -80,7 +80,7 @@ spec:
             exec:
               command:
               - /csi-node-driver-registrar
-              - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
+              - --kubelet-registration-path={{ .Values.csiNode.prefixPath }}/var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] Chart version has been incremented (if necessary)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

When using the prefix for RancherOS nodes, the liveness probe fails. The vsphere-csi-node-xxx pods keep in a Crashloopbackoff state. The reason is that the prefix path is not added to the kubelet-registration-path of the liveness probe. Added the optional prefix to the kubelet-registration-path.

#### Linked Issues ####

N/A

#### Additional Notes ####

N/A

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.