### PR TITLE
v1.26.0 CSI and CPI chart image versions

### DIFF
--- a/charts/rancher-vsphere-cpi/values.yaml
+++ b/charts/rancher-vsphere-cpi/values.yaml
@@ -28,6 +28,11 @@ vCenter:
 # - On running a helm template, Helm generally assumes the kubeVersion is v1.20.0
 # - On running a helm install --dry-run, the correct kubeVersion should be chosen.
 versionOverrides:
+  - constraint: "~ 1.27"
+    values:
+      cloudControllerManager:
+        repository: rancher/mirrored-cloud-provider-vsphere-cpi-release-manager
+        tag: v1.26.0
   - constraint: "~ 1.26"
     values:
       cloudControllerManager:

--- a/charts/rancher-vsphere-cpi/values.yaml
+++ b/charts/rancher-vsphere-cpi/values.yaml
@@ -28,6 +28,11 @@ vCenter:
 # - On running a helm template, Helm generally assumes the kubeVersion is v1.20.0
 # - On running a helm install --dry-run, the correct kubeVersion should be chosen.
 versionOverrides:
+  - constraint: "~ 1.26"
+    values:
+      cloudControllerManager:
+        repository: rancher/mirrored-cloud-provider-vsphere-cpi-release-manager
+        tag: v1.26.0
   - constraint: "~ 1.25"
     values:
       cloudControllerManager:

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -25,7 +25,7 @@ csiController:
     enabled: false
   image:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
-    tag: v2.7.0
+    tag: v3.0.1
     csiAttacher:
       repository: rancher/mirrored-sig-storage-csi-attacher
       tag: v3.4.0
@@ -37,7 +37,7 @@ csiController:
       tag: v2.6.0
     vsphereSyncer:
       repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
-      tag: v2.7.1
+      tag: v3.0.1
     csiProvisioner:
       repository: rancher/mirrored-sig-storage-csi-provisioner
       tag: v3.1.0
@@ -101,7 +101,7 @@ csiNode:
   prefixPath: ""
   image:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
-    tag: v2.7.0
+    tag: 3.0.1
     nodeDriverRegistrar:
       repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
       tag: v2.5.0
@@ -122,12 +122,43 @@ global:
     systemDefaultRegistry: ""
 
 versionOverrides:
+  - constraint: "~ 1.27"
+    values:
+      csiController:
+        image:
+          repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
+          tag: v3.0.1
+          csiAttacher:
+            repository: rancher/mirrored-sig-storage-csi-attacher
+            tag: v3.4.0
+          csiResizer:
+            repository: rancher/mirrored-sig-storage-csi-resizer
+            tag: v1.4.0
+          livenessProbe:
+            repository: rancher/mirrored-sig-storage-livenessprobe
+            tag: v2.7.0
+          vsphereSyncer:
+            repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
+            tag: v3.0.1
+          csiProvisioner:
+            repository: rancher/mirrored-sig-storage-csi-provisioner
+            tag: v3.2.1
+      csiNode:
+        image:
+          repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
+          tag: v3.0.1
+          nodeDriverRegistrar:
+            repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
+            tag: v2.5.1
+          livenessProbe:
+            repository: rancher/mirrored-sig-storage-livenessprobe
+            tag: v2.7.0
   - constraint: "~ 1.26"
     values:
       csiController:
         image:
           repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
-          tag: v2.7.0
+          tag: v2.7.1
           csiAttacher:
             repository: rancher/mirrored-sig-storage-csi-attacher
             tag: v3.4.0
@@ -146,7 +177,7 @@ versionOverrides:
       csiNode:
         image:
           repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
-          tag: v2.7.0
+          tag: v2.7.1
           nodeDriverRegistrar:
             repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
             tag: v2.5.1
@@ -158,7 +189,7 @@ versionOverrides:
       csiController:
         image:
           repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
-          tag: v2.7.0
+          tag: v2.7.1
           csiAttacher:
             repository: rancher/mirrored-sig-storage-csi-attacher
             tag: v3.4.0
@@ -170,14 +201,14 @@ versionOverrides:
             tag: v2.7.0
           vsphereSyncer:
             repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
-            tag: v2.7.0
+            tag: v2.7.1
           csiProvisioner:
             repository: rancher/mirrored-sig-storage-csi-provisioner
             tag: v3.2.1
       csiNode:
         image:
           repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
-          tag: v2.7.0
+          tag: v2.7.1
           nodeDriverRegistrar:
             repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
             tag: v2.5.1

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -25,7 +25,7 @@ csiController:
     enabled: false
   image:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
-    tag: v3.0.1
+    tag: v2.6.2
     csiAttacher:
       repository: rancher/mirrored-sig-storage-csi-attacher
       tag: v3.4.0
@@ -37,7 +37,7 @@ csiController:
       tag: v2.6.0
     vsphereSyncer:
       repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
-      tag: v3.0.1
+      tag: v2.6.2
     csiProvisioner:
       repository: rancher/mirrored-sig-storage-csi-provisioner
       tag: v3.1.0
@@ -101,7 +101,7 @@ csiNode:
   prefixPath: ""
   image:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
-    tag: 3.0.1
+    tag: v2.6.2
     nodeDriverRegistrar:
       repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
       tag: v2.5.0

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -25,7 +25,7 @@ csiController:
     enabled: false
   image:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
-    tag: v2.6.2
+    tag: v2.7.0
     csiAttacher:
       repository: rancher/mirrored-sig-storage-csi-attacher
       tag: v3.4.0
@@ -37,7 +37,7 @@ csiController:
       tag: v2.6.0
     vsphereSyncer:
       repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
-      tag: v2.6.2
+      tag: v2.7.1
     csiProvisioner:
       repository: rancher/mirrored-sig-storage-csi-provisioner
       tag: v3.1.0
@@ -101,7 +101,7 @@ csiNode:
   prefixPath: ""
   image:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
-    tag: v2.6.2
+    tag: v2.7.0
     nodeDriverRegistrar:
       repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
       tag: v2.5.0
@@ -122,6 +122,37 @@ global:
     systemDefaultRegistry: ""
 
 versionOverrides:
+  - constraint: "~ 1.26"
+    values:
+      csiController:
+        image:
+          repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
+          tag: v2.7.0
+          csiAttacher:
+            repository: rancher/mirrored-sig-storage-csi-attacher
+            tag: v3.4.0
+          csiResizer:
+            repository: rancher/mirrored-sig-storage-csi-resizer
+            tag: v1.4.0
+          livenessProbe:
+            repository: rancher/mirrored-sig-storage-livenessprobe
+            tag: v2.7.0
+          vsphereSyncer:
+            repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
+            tag: v2.7.1
+          csiProvisioner:
+            repository: rancher/mirrored-sig-storage-csi-provisioner
+            tag: v3.2.1
+      csiNode:
+        image:
+          repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
+          tag: v2.7.0
+          nodeDriverRegistrar:
+            repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
+            tag: v2.5.1
+          livenessProbe:
+            repository: rancher/mirrored-sig-storage-livenessprobe
+            tag: v2.7.0
   - constraint: "~ 1.25"
     values:
       csiController:
@@ -158,7 +189,7 @@ versionOverrides:
       csiController:
         image:
           repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
-          tag: v2.6.2
+          tag: v2.6.3
           csiAttacher:
             repository: rancher/mirrored-sig-storage-csi-attacher
             tag: v3.4.0
@@ -170,14 +201,14 @@ versionOverrides:
             tag: v2.7.0
           vsphereSyncer:
             repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
-            tag: v2.6.2
+            tag: v2.6.3
           csiProvisioner:
             repository: rancher/mirrored-sig-storage-csi-provisioner
             tag: v3.2.1
       csiNode:
         image:
           repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
-          tag: v2.6.2
+          tag: v2.6.3
           nodeDriverRegistrar:
             repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
             tag: v2.5.1

--- a/tests/unit/cpi_template_test.go
+++ b/tests/unit/cpi_template_test.go
@@ -29,6 +29,17 @@ func TestCPITemplateRenderedDaemonset(t *testing.T) {
 		args args
 	}{
 		{
+			name: "Kubernetes 1.27",
+			args: args{
+				values:        map[string]string{},
+				kubeVersion:   "1.27",
+				namespace:     "cpitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:   "cpitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:  cpiChart,
+				expectedImage: "rancher/mirrored-cloud-provider-vsphere-cpi-release-manager:v1.26.0",
+			},
+		},
+		{
 			name: "Kubernetes 1.26",
 			args: args{
 				values:        map[string]string{},

--- a/tests/unit/cpi_template_test.go
+++ b/tests/unit/cpi_template_test.go
@@ -29,6 +29,17 @@ func TestCPITemplateRenderedDaemonset(t *testing.T) {
 		args args
 	}{
 		{
+			name: "Kubernetes 1.26",
+			args: args{
+				values:        map[string]string{},
+				kubeVersion:   "1.26",
+				namespace:     "cpitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:   "cpitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:  cpiChart,
+				expectedImage: "rancher/mirrored-cloud-provider-vsphere-cpi-release-manager:v1.26.0",
+			},
+		},
+		{
 			name: "Kubernetes 1.25",
 			args: args{
 				values:        map[string]string{},

--- a/tests/unit/csi_template_test.go
+++ b/tests/unit/csi_template_test.go
@@ -29,6 +29,40 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 		args args
 	}{
 		{
+			name: "Kubernetes 1.27 Linux Only",
+			args: args{
+				values:         map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:    "1.27",
+				namespace:      "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:    "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:   csiChart,
+				windowsEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.1",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.0.1",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.27 Linux and Windows",
+			args: args{
+				values: map[string]string{
+					"vCenter.clusterId":         random.UniqueId(),
+					"csiWindowsSupport:enabled": "true",
+				},
+				kubeVersion:  "1.27",
+				namespace:    "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:  "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath: csiChart,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.1",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.0.1",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
+				},
+			},
+		},
+		{
 			name: "Kubernetes 1.26 Linux Only",
 			args: args{
 				values:         map[string]string{"vCenter.clusterId": random.UniqueId()},
@@ -39,7 +73,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				windowsEnabled: false,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.1",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.7.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.7.1",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
 				},
 			},
@@ -57,7 +91,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				chartRelPath: csiChart,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.1",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.7.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.7.1",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
 				},
 			},
@@ -73,7 +107,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				windowsEnabled: false,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.1",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.7.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.7.1",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
 				},
 			},
@@ -91,7 +125,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				chartRelPath: csiChart,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.1",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.7.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.7.1",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
 				},
 			},
@@ -107,7 +141,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				windowsEnabled: false,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.1",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.6.2",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.6.3",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
 				},
 			},
@@ -125,7 +159,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				chartRelPath: csiChart,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.1",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.6.2",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.6.3",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
 				},
 			},
@@ -326,6 +360,86 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 		args args
 	}{
 		{
+			name: "Kubernetes 1.27 with CSI Resizer Enabled",
+			args: args{
+				values: map[string]string{
+					"vCenter.clusterId":                random.UniqueId(),
+					"csiController.csiResizer.enabled": "true",
+				},
+				kubeVersion:       "1.27",
+				namespace:         "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:       "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:      csiChart,
+				csiResizerEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-attacher:v3.4.0",
+					"rancher/mirrored-sig-storage-csi-resizer:v1.4.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.0.1",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.0.1",
+					"rancher/mirrored-sig-storage-csi-provisioner:v3.2.1",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.27",
+			args: args{
+				values:            map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:       "1.27",
+				namespace:         "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:       "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:      csiChart,
+				csiResizerEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-attacher:v3.4.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.0.1",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.0.1",
+					"rancher/mirrored-sig-storage-csi-provisioner:v3.2.1",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.26 with CSI Resizer Enabled",
+			args: args{
+				values: map[string]string{
+					"vCenter.clusterId":                random.UniqueId(),
+					"csiController.csiResizer.enabled": "true",
+				},
+				kubeVersion:       "1.26",
+				namespace:         "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:       "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:      csiChart,
+				csiResizerEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-attacher:v3.4.0",
+					"rancher/mirrored-sig-storage-csi-resizer:v1.4.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.7.1",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.7.1",
+					"rancher/mirrored-sig-storage-csi-provisioner:v3.2.1",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.26",
+			args: args{
+				values:            map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:       "1.26",
+				namespace:         "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:       "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:      csiChart,
+				csiResizerEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-attacher:v3.4.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.7.1",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.7.1",
+					"rancher/mirrored-sig-storage-csi-provisioner:v3.2.1",
+				},
+			},
+		},
+		{
 			name: "Kubernetes 1.25 with CSI Resizer Enabled",
 			args: args{
 				values: map[string]string{
@@ -340,9 +454,9 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-attacher:v3.4.0",
 					"rancher/mirrored-sig-storage-csi-resizer:v1.4.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.7.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.7.1",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.7.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.7.1",
 					"rancher/mirrored-sig-storage-csi-provisioner:v3.2.1",
 				},
 			},
@@ -358,9 +472,9 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				csiResizerEnabled: false,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-attacher:v3.4.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.7.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.7.1",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.7.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.7.1",
 					"rancher/mirrored-sig-storage-csi-provisioner:v3.2.1",
 				},
 			},
@@ -380,9 +494,9 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-attacher:v3.4.0",
 					"rancher/mirrored-sig-storage-csi-resizer:v1.4.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.6.2",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.6.3",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.6.2",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.6.3",
 					"rancher/mirrored-sig-storage-csi-provisioner:v3.2.1",
 				},
 			},
@@ -398,9 +512,9 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				csiResizerEnabled: false,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-attacher:v3.4.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.6.2",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.6.3",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.6.2",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v2.6.3",
 					"rancher/mirrored-sig-storage-csi-provisioner:v3.2.1",
 				},
 			},
@@ -565,6 +679,48 @@ func TestCSITemplateRenderedControllerDeploymentArgs(t *testing.T) {
 		args args
 	}{
 		{
+			name: "Kubernetes 1.27",
+			args: args{
+				values:       map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:  "1.27",
+				namespace:    "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:  "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath: csiChart,
+				expectedArgs: []string{
+					"--fss-name=internal-feature-states.csi.vsphere.vmware.com",
+					"--fss-namespace=$(CSI_NAMESPACE)",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.26",
+			args: args{
+				values:       map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:  "1.26",
+				namespace:    "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:  "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath: csiChart,
+				expectedArgs: []string{
+					"--fss-name=internal-feature-states.csi.vsphere.vmware.com",
+					"--fss-namespace=$(CSI_NAMESPACE)",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.25",
+			args: args{
+				values:       map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:  "1.25",
+				namespace:    "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:  "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath: csiChart,
+				expectedArgs: []string{
+					"--fss-name=internal-feature-states.csi.vsphere.vmware.com",
+					"--fss-namespace=$(CSI_NAMESPACE)",
+				},
+			},
+		},
+		{
 			name: "Kubernetes 1.24",
 			args: args{
 				values:       map[string]string{"vCenter.clusterId": random.UniqueId()},
@@ -685,6 +841,48 @@ func TestCSITemplateRenderedNodeDaemonSetArgs(t *testing.T) {
 		name string
 		args args
 	}{
+		{
+			name: "Kubernetes 1.27",
+			args: args{
+				values:       map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:  "1.27",
+				namespace:    "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:  "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath: csiChart,
+				expectedArgs: []string{
+					"--fss-name=internal-feature-states.csi.vsphere.vmware.com",
+					"--fss-namespace=$(CSI_NAMESPACE)",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.26",
+			args: args{
+				values:       map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:  "1.26",
+				namespace:    "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:  "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath: csiChart,
+				expectedArgs: []string{
+					"--fss-name=internal-feature-states.csi.vsphere.vmware.com",
+					"--fss-namespace=$(CSI_NAMESPACE)",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.25",
+			args: args{
+				values:       map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:  "1.25",
+				namespace:    "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:  "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath: csiChart,
+				expectedArgs: []string{
+					"--fss-name=internal-feature-states.csi.vsphere.vmware.com",
+					"--fss-namespace=$(CSI_NAMESPACE)",
+				},
+			},
+		},
 		{
 			name: "Kubernetes 1.24",
 			args: args{

--- a/tests/unit/csi_template_test.go
+++ b/tests/unit/csi_template_test.go
@@ -29,6 +29,40 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 		args args
 	}{
 		{
+			name: "Kubernetes 1.26 Linux Only",
+			args: args{
+				values:         map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:    "1.26",
+				namespace:      "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:    "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:   csiChart,
+				windowsEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.1",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.7.0",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.26 Linux and Windows",
+			args: args{
+				values: map[string]string{
+					"vCenter.clusterId":         random.UniqueId(),
+					"csiWindowsSupport:enabled": "true",
+				},
+				kubeVersion:  "1.26",
+				namespace:    "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:  "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath: csiChart,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.5.1",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v2.7.0",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.7.0",
+				},
+			},
+		},
+		{
 			name: "Kubernetes 1.25 Linux Only",
 			args: args{
 				values:         map[string]string{"vCenter.clusterId": random.UniqueId()},


### PR DESCRIPTION
https://github.com/rancher/image-mirror/pull/362 is a Prerequisite to this PR
#### Pull Request Checklist ####

- [X] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [X] Chart version has been incremented (if necessary)
- [X] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####
Added new Image version

    CSI  2.7.1, 3.0.1
    CPI 1.26.0 (note k8s v1.27.0 will pin to 1.26.0 as that is the latest release ATM)

Update image version:
   CSI 2.6.2 -> 2.6.3
   CSI 2.7.0 -> 2.7.1
   
<!-- New image, version bump. script update, etc etc -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.