### PR TITLE
updated chart objects to have labels

### DIFF
--- a/charts/rancher-vsphere-cpi/templates/_helpers.tpl
+++ b/charts/rancher-vsphere-cpi/templates/_helpers.tpl
@@ -30,3 +30,21 @@ add below linux tolerations to workloads could be scheduled to those linux nodes
 {{- define "linux-node-selector" -}}
 kubernetes.io/os: linux
 {{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chartName" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Labels that should be added on each resource
+*/}}
+{{- define "labels" -}}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ include "chartName" . }}
+{{- end -}}
+
+

--- a/charts/rancher-vsphere-cpi/templates/configmap.yaml
+++ b/charts/rancher-vsphere-cpi/templates/configmap.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     vsphere-cpi-infra: config
     component: {{ .Chart.Name }}-cloud-controller-manager
+    {{- include "labels" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
 data:
   vsphere.yaml: |

--- a/charts/rancher-vsphere-cpi/templates/daemonset.yaml
+++ b/charts/rancher-vsphere-cpi/templates/daemonset.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     component: {{ .Chart.Name }}-cloud-controller-manager
     tier: control-plane
+  {{- include "labels" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ""
@@ -21,6 +22,10 @@ spec:
         name: {{ .Chart.Name }}-cloud-controller-manager
         component: {{ .Chart.Name }}-cloud-controller-manager
         tier: control-plane
+        {{- include "labels" . | nindent 8 }}
+      {{- with .Values.cloudControllerManager.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.cloudControllerManager.nodeSelector }}
       nodeSelector: {{ include "linux-node-selector" . | nindent 8 }}

--- a/charts/rancher-vsphere-cpi/templates/role-binding.yaml
+++ b/charts/rancher-vsphere-cpi/templates/role-binding.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     vsphere-cpi-infra: role-binding
     component: {{ .Chart.Name }}-cloud-controller-manager
+    {{- include "labels" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -27,6 +28,7 @@ metadata:
   labels:
     vsphere-cpi-infra: cluster-role-binding
     component: {{ .Chart.Name }}-cloud-controller-manager
+    {{- include "labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/rancher-vsphere-cpi/templates/role.yaml
+++ b/charts/rancher-vsphere-cpi/templates/role.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     vsphere-cpi-infra: role
     component: {{ .Chart.Name }}-cloud-controller-manager
+    {{- include "labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/charts/rancher-vsphere-cpi/templates/secret.yaml
+++ b/charts/rancher-vsphere-cpi/templates/secret.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     vsphere-cpi-infra: secret
     component: {{ .Chart.Name }}-cloud-controller-manager
+    {{- include "labels" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
 data:
   {{ .Values.vCenter.host }}.username: {{ .Values.vCenter.username | b64enc | quote }}

--- a/charts/rancher-vsphere-cpi/templates/service-account.yaml
+++ b/charts/rancher-vsphere-cpi/templates/service-account.yaml
@@ -6,5 +6,6 @@ metadata:
   labels:
     vsphere-cpi-infra: service-account
     component: {{ .Chart.Name }}-cloud-controller-manager
+    {{- include "labels" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/charts/rancher-vsphere-cpi/templates/service.yaml
+++ b/charts/rancher-vsphere-cpi/templates/service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   labels:
     component: {{ .Chart.Name }}-cloud-controller-manager
+    {{- include "labels" . | nindent 4 }}
   name: {{ .Chart.Name }}-cloud-controller-manager
   namespace: {{ .Release.Namespace }}
 spec:

--- a/charts/rancher-vsphere-cpi/values.yaml
+++ b/charts/rancher-vsphere-cpi/values.yaml
@@ -88,6 +88,8 @@ cloudControllerManager:
   tag: latest
   nodeSelector: {}
   tolerations: []
+  ## Optional additional labels to add to pods
+  podLabels: {}
   rbac:
     enabled: true
 

--- a/charts/rancher-vsphere-csi/templates/_helpers.tpl
+++ b/charts/rancher-vsphere-csi/templates/_helpers.tpl
@@ -30,3 +30,19 @@ add below linux tolerations to workloads could be scheduled to those linux nodes
 {{- define "linux-node-selector" -}}
 kubernetes.io/os: linux
 {{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chartName" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Labels that should be added on each resource
+*/}}
+{{- define "labels" -}}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ include "chartName" . }}
+{{- end -}}

--- a/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
+++ b/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
@@ -4,6 +4,8 @@ apiVersion: apps/v1
 metadata:
   name: vsphere-csi-controller
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels" . | nindent 4 }}
 spec:
   replicas: 3
   strategy:
@@ -19,6 +21,10 @@ spec:
       labels:
         app: vsphere-csi-controller
         role: vsphere-csi
+        {{- include "labels" . | nindent 8 }}
+      {{- with .Values.csiController.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: vsphere-csi-controller
       {{- if .Values.csiController.nodeSelector }}

--- a/charts/rancher-vsphere-csi/templates/controller/role-binding.yaml
+++ b/charts/rancher-vsphere-csi/templates/controller/role-binding.yaml
@@ -2,6 +2,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: vsphere-csi-controller-binding
+  labels:
+    {{- include "labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: vsphere-csi-controller

--- a/charts/rancher-vsphere-csi/templates/controller/role.yaml
+++ b/charts/rancher-vsphere-csi/templates/controller/role.yaml
@@ -2,6 +2,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: vsphere-csi-controller-role
+  labels:
+    {{- include "labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["nodes", "pods", "configmaps"]

--- a/charts/rancher-vsphere-csi/templates/controller/service-account.yaml
+++ b/charts/rancher-vsphere-csi/templates/controller/service-account.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 metadata:
   name: vsphere-csi-controller
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels" . | nindent 4 }}

--- a/charts/rancher-vsphere-csi/templates/controller/service.yaml
+++ b/charts/rancher-vsphere-csi/templates/controller/service.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: vsphere-csi-controller
+    {{- include "labels" . | nindent 4 }}
 spec:
   ports:
     - name: ctlr

--- a/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
@@ -4,6 +4,8 @@ apiVersion: apps/v1
 metadata:
   name: vsphere-csi-node
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -17,6 +19,10 @@ spec:
       labels:
         app: vsphere-csi-node
         role: vsphere-csi
+        {{- include "labels" . | nindent 8 }}
+      {{- with .Values.csiNode.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.csiNode.nodeSelector }}
       nodeSelector: {{ include "linux-node-selector" . | nindent 8 }}

--- a/charts/rancher-vsphere-csi/templates/node/role-binding.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/role-binding.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: vsphere-csi-node-binding
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: vsphere-csi-node
@@ -18,6 +20,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: vsphere-csi-node-cluster-role-binding
+  labels:
+    {{- include "labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: vsphere-csi-node

--- a/charts/rancher-vsphere-csi/templates/node/role.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: vsphere-csi-node-role
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -12,6 +14,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: vsphere-csi-node-cluster-role
+  labels:
+    {{- include "labels" . | nindent 4 }}
 rules:
   - apiGroups: ["cns.vmware.com"]
     resources: ["csinodetopologies"]

--- a/charts/rancher-vsphere-csi/templates/node/service-account.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/service-account.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 metadata:
   name: vsphere-csi-node
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "labels" . | nindent 4 }}

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -56,6 +56,9 @@ csiController:
   #   operator: Exists
   #   effect: NoExecute
   #   tolerationSeconds: 30
+  ##
+  ## Optional additional labels to add to pods
+  podLabels: {}
 
 # Internal features
 csiMigration:
@@ -98,6 +101,8 @@ csiNode:
   nodeSelector: {}
   ## List of node taints to tolerate (requires Kubernetes >= 1.6)
   tolerations: []
+  ## Optional additional labels to add to pods
+  podLabels: {} 
   prefixPath: ""
   image:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver


### PR DESCRIPTION
#### Pull Request Checklist ####

* Adding a common label for both charts with a helper function
* Adding the ability to have pod labels

#### Types of Change ####

* updated helm charts

#### Linked Issues ####

https://github.com/rancher/vsphere-charts/issues/33

#### Additional Notes ####

tested in private rancher cluster

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.