### PR TITLE
rancher-rke2:4025 - Updating windows prefix path

### DIFF
--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -23,4 +23,4 @@ maintainers:
 name: rancher-vsphere-csi
 sources:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.0.2-rancher1
+version: 3.0.2-rancher2

--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
   catalog.cattle.io/rancher-version: '>= 2.8.0-0'
   catalog.cattle.io/release-name: vsphere-csi
 apiVersion: v1
-appVersion: 3.0.2-rancher1
+appVersion: 3.0.2-rancher2
 description: vSphere Cloud Storage Interface (CSI)
 icon: https://charts.rancher.io/assets/logos/vsphere-csi.svg
 keywords:
@@ -23,4 +23,4 @@ maintainers:
 name: rancher-vsphere-csi
 sources:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.0.2-rancher2
+version: 3.0.2-rancher1

--- a/charts/rancher-vsphere-csi/questions.yaml
+++ b/charts/rancher-vsphere-csi/questions.yaml
@@ -146,3 +146,10 @@ questions:
     type: string
     default: ""
     group: Node Configuration
+
+  - variable: csiNode.prefixPathWindows
+    label: Prefix Path for `/var/lib/kubelet`
+    description: For some operating systems including RancherOS, RKE prefixes `/var/lib/kubelet` with `/opt/rke`. For Windows, this will likely be the default value, which is 'C:'
+    type: string
+    default: ""
+    group: Node Configuration

--- a/charts/rancher-vsphere-csi/templates/node/windows-daemonset.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/windows-daemonset.yaml
@@ -57,7 +57,7 @@ spec:
             - name: ADDRESS
               value: 'unix://C:\\csi\\csi.sock'
             - name: DRIVER_REG_SOCK_PATH
-              value: {{ .Values.csiNode.prefixPath }}'\\var\\lib\\kubelet\\plugins\\csi.vsphere.vmware.com\\csi.sock'
+              value: '{{ .Values.csiNode.prefixPathWindows | default "C:" }}\\var\\lib\\kubelet\\plugins\\csi.vsphere.vmware.com\\csi.sock'
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -99,6 +99,7 @@ csiNode:
   ## List of node taints to tolerate (requires Kubernetes >= 1.6)
   tolerations: []
   prefixPath: ""
+  prefixPathWindows: ""
   image:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
     tag: latest


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] Chart version has been incremented (if necessary)
- [x] That helm lint and pack run successfully on the chart.
- [ ] Deployment of the chart has been tested and verified that it functions as expected.
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####
Updating windows prefix path. Currently this does not work properly, see linked issue.

#### Linked Issues ####

https://github.com/rancher/rke2/issues/4025

#### Additional Notes ####

Unit tests passed, lint passed.

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.