### PR TITLE
Feat/accept list of vcenter dcs

### DIFF
--- a/charts/rancher-vsphere-cpi/Chart.yaml
+++ b/charts/rancher-vsphere-cpi/Chart.yaml
@@ -23,4 +23,4 @@ maintainers:
 name: rancher-vsphere-cpi
 sources:
 - https://github.com/kubernetes/cloud-provider-vsphere
-version: 1.6.0
+version: 1.7.0

--- a/charts/rancher-vsphere-cpi/templates/configmap.yaml
+++ b/charts/rancher-vsphere-cpi/templates/configmap.yaml
@@ -21,8 +21,10 @@ data:
     vcenter:
       {{ .host | quote }}:
         server: {{ .host | quote }}
+      {{- range $datacenter := .datacenters }}
         datacenters:
-          - {{ .datacenters | quote }}
+          - {{ $datacenter | quote }}
+      {{- end }}
     {{- if .labels.generate }}
 
     # labels for regions and zones

--- a/charts/rancher-vsphere-cpi/templates/configmap.yaml
+++ b/charts/rancher-vsphere-cpi/templates/configmap.yaml
@@ -21,8 +21,8 @@ data:
     vcenter:
       {{ .host | quote }}:
         server: {{ .host | quote }}
-      {{- range $datacenter := .datacenters }}
         datacenters:
+      {{- range $datacenter := .datacenters }}
           - {{ $datacenter | quote }}
       {{- end }}
     {{- if .labels.generate }}

--- a/charts/rancher-vsphere-cpi/values.yaml
+++ b/charts/rancher-vsphere-cpi/values.yaml
@@ -2,7 +2,7 @@ vCenter:
   host: ""
   port: 443
   insecureFlag: true
-  datacenters: ""
+  datacenters: []
   username: ""
   password: ""
   credentialsSecret:


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] Chart version has been incremented (if necessary)
- [x] That helm lint and pack run successfully on the chart.
- [ ] Deployment of the chart has been tested and verified that it functions as expected.
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->
Feature:  Accept an array of vCenter.datacenters instead of a string array.

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

```
helm lint charts/rancher-vsphere-cpi 
==> Linting charts/rancher-vsphere-cpi

1 chart(s) linted, 0 chart(s) failed
```

```
values.yaml
-----------
vCenter:
  host: "foo"
  datacenters: ["/foo-bar","/baz-foo"]

helm template charts/rancher-vsphere-cpi | yq '. | select(.kind=="ConfigMap")'
# Source: rancher-vsphere-cpi/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: vsphere-cloud-config
  labels:
    vsphere-cpi-infra: config
    component: rancher-vsphere-cpi-cloud-controller-manager
    app.kubernetes.io/version: "1.27.0"
    app.kubernetes.io/managed-by: Helm
    helm.sh/chart: rancher-vsphere-cpi-1.6.0
  namespace: default
data:
  vsphere.yaml: |
    # Global properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.

    global:
      secretName: "vsphere-cpi-creds"
      secretNamespace: "default"
      port: 443
      insecureFlag: true

    # vcenter section
    vcenter:
      "foo":
        server: "foo"
        datacenters:
          - "/foo-bar"
          - "/baz-foo"
 ```

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.