### PR TITLE
Update images for k8s 1.28 support

### DIFF
--- a/DEVELOPING.MD
+++ b/DEVELOPING.MD
@@ -1,12 +1,12 @@
 # Developer Guide for vSphere Charts for Rancher
 
-This guide is going to highlight the steps that are required to develop and maintian the vSphere charts for [CPI](https://github.com/kubernetes/cloud-provider-vsphere) and [CSI](https://github.com/kubernetes-sigs/vsphere-csi-driver) for Rancher. Upstream is only releasing manifests at this point and they do that in version specific branches. We use these upstream manifests to create the charts that we use. This makes the process a touch more complex as each manifest needs to be compared to the helm chart template to make the appropriate changes. Since we mirror images into our own container registry, we also have to check the manifests every time a release happens to gather the correct image versions to keep our registry synced. Once the charts and images have been updated, we then need to ensure that the charts are updated in [Rancher Charts](https://github.com/rancher/charts), [RKE2-Charts](https://github.com/rancher/rke2-charts), and [RKE2](https://github.com/rancher/rke2).  
+This guide is going to highlight the steps that are required to develop and maintian the vSphere charts for [CPI](https://github.com/kubernetes/cloud-provider-vsphere) and [CSI](https://github.com/kubernetes-sigs/vsphere-csi-driver) for Rancher. Upstream is only releasing manifests at this point and they do that in version specific branches. We use these upstream manifests to create the charts that we use. This makes the process a touch more complex as each manifest needs to be compared to the helm chart template to make the appropriate changes. Since we mirror images into our own container registry, we also have to check the manifests every time a release happens to gather the correct image versions to keep our registry synced. Once the charts and images have been updated, we then need to ensure that the charts are updated in [Rancher Charts](https://github.com/rancher/charts), [RKE2-Charts](https://github.com/rancher/rke2-charts), and [RKE2](https://github.com/rancher/rke2).
 
-#### You may be asking why both Rancher charts and RKE2? 
+#### You may be asking why both Rancher charts and RKE2?
 
-RKE2 embeds the charts that it ships with each version of RKE2 that is released. This means that RKE2 always uses its own version of the vSphere charts regardless if deployed standalone or through Rancher. The charts being deployed are determined by the selected cloud provider when provisioning. Rancher charts shouldn't be consumed for RKE2 and currently exist for use with non-RKE2 clusters that are provisioned in Rancher, primarily RKE1. 
+RKE2 embeds the charts that it ships with each version of RKE2 that is released. This means that RKE2 always uses its own version of the vSphere charts regardless if deployed standalone or through Rancher. The charts being deployed are determined by the selected cloud provider when provisioning. Rancher charts shouldn't be consumed for RKE2 and currently exist for use with non-RKE2 clusters that are provisioned in Rancher, primarily RKE1.
 
-#### Upstream Releases 
+#### Upstream Releases
 
 Upstream releases are not immediate when a new version of Kubernetes is released. This means that the charts typically lag behind the Kubernetes version by at least a month if not longer. This often means that users can't upgrade clusters immediately or deploy the newest version that is released in RKE2 or Rancher with full support.
 
@@ -20,7 +20,7 @@ Both the CSI and CPI charts in this repository are designed to be what have been
 
 By creating a super chart, it means there is only ever one chart and we can ensure that users are always getting the most up to date images based on their Kubernetes version. This technique is used in other charts inside of Rancher.
 
-## Development  
+## Development
 
 Features and upstream releases are the primary reason to be working in this repository. Upstream releases through either bug fixes or new Kubernetes version support is the majority of the work that is required. Below is a high level of the steps that need to occur.
 
@@ -33,7 +33,7 @@ Features and upstream releases are the primary reason to be working in this repo
 * Check with RKE2 on the next release cycle and plan out PRs for getting these changes included by the target release date.
 * Update Rancher Charts with the new versions
 
-Before getting started, it is suggested to create an issue in the Rancher/Rancher repository to track the work that has to occur. It spans several different repositories which is often hard to coordinate. Here is the recommend issue format. 
+Before getting started, it is suggested to create an issue in the Rancher/Rancher repository to track the work that has to occur. It spans several different repositories which is often hard to coordinate. Here is the recommend issue format.
 
 ```
 **Is your feature request related to a problem? Please describe.**
@@ -54,7 +54,7 @@ Before getting started, it is suggested to create an issue in the Rancher/Ranche
 - [ ] Updated RKE2 to consume new chart (RKE2 team)
 ```
 
-For every PR, link back to this issue so everything can be tracked. Whoever does the RKE2 updates will need to create a separate issue in the RKE2 repository in addition to the Rancher one. 
+For every PR, link back to this issue so everything can be tracked. Whoever does the RKE2 updates will need to create a separate issue in the RKE2 repository in addition to the Rancher one.
 
 Here are some examples:
 
@@ -63,11 +63,13 @@ Here are some examples:
 
 ### Step 1: Checking upstream manifests
 
-There are two goals when checking upstream manifests. The first goal is to check to see if any image versions have been updated and the second is to check if any changes in the manifests have occured. 
+NOTE: the charts _do not match_ the upstream charts exactly - the `rancher/vsphere-charts` package actually predates those by a lot due to the fact that upstream did NOT ship a chart instead they just shipped raw manifests which isn't very easy to package/update. Engineers used those initial manifests and made these from them.
+
+There are two goals when checking upstream manifests. The first goal is to check to see if any image versions have been updated and the second is to check if any changes in the manifests have occured.
 
 If you find that image versions have been updated, then you will need to make a pull request to the [image-mirror](https://github.com/rancher/image-mirror) repository first before proceeding. [Here](https://github.com/rancher/image-mirror/pull/261) is an example PR and follow the requirements outlined in the PR template for those changes. After the images have been checked and image-mirror updated with any new images or image versions, then proceed to check check the manifests.
 
-Checking the manifests is best done by doing a tag compare in each upstream chart. Compare an upstream tag to the tag that the rancher chart is based off of by viewing the `Full Changelog` for that tag. This compares the manifest directories. If there is a change that needs to be added to charts in this repository, bring it in. [Here](https://github.com/kubernetes/cloud-provider-vsphere/compare/v1.25.0...v1.24.2) is an example.
+Checking the manifests is best done by doing a tag compare in each upstream chart. Compare an upstream tag to the tag that the rancher chart is based off of by viewing the `Full Changelog` for that tag. This compares the manifest directories. If there is a change that needs to be added to charts in this repository, bring it in. [Here](https://github.com/kubernetes/cloud-provider-vsphere/compare/v1.25.0...v1.24.2) is an example. Just look for important changes and bring them into this chart as necessary. New environment variables, configs, etc.
 
 Make sure that the unit tests for each chart have been updated, or new tests or test cases are added based on the set of manifest changes.
 
@@ -122,7 +124,7 @@ If everything passes here then it's time to test deployment to a cluster. If som
 At this stage, it's now safe to test the charts on a real cluster. Typically, a RKE1 cluster is deployed on vSphere using Rancher. Then the kubeconfig is downloaded from the cluster and used to deploy the local chart to the cluster using helm. Here is an example.
 
 ```
-$ helm install -f values.yaml --kubeconfig <path to kube config> csi ./charts/rancher-vsphere-csi 
+$ helm install -f values.yaml --kubeconfig <path to kube config> csi ./charts/rancher-vsphere-csi
 ```
 
 ```
@@ -148,15 +150,15 @@ If you want to test that CPI is functioning properly, add the `node.cloudprovide
 
 If you deploy CPI via the Rancher UI, **do not** `Define vSphere Tags` without specifying the `Region` and `Zone` in which to tag pods. This will cause the chart to malfunction and the kubelet will not remove taints or set the provider ID on the nodes.
 
-Ensure that all pods for both the CPI and CSI charts come up without errors. Make sure that the provider gets set on each node to be vSphere. 
+Ensure that all pods for both the CPI and CSI charts come up without errors. Make sure that the provider gets set on each node to be vSphere.
 
 ### Step 4: PR to Rancher vSphere Charts Repository
 
-You are now ready to submit a PR to the vSphere charts repository. Fill out the PR template and request reviews. Once the PR has been approved and passed the Drone run, you can merge. [Here](https://github.com/rancher/vsphere-charts/pull/35) is an example PR. 
+You are now ready to submit a PR to the vSphere charts repository. Fill out the PR template and request reviews. Once the PR has been approved and passed the Drone run, you can merge. [Here](https://github.com/rancher/vsphere-charts/pull/35) is an example PR.
 
 ### Step 5: Create RKE2-Charts PR
 
-A member from the RKE2 team can now pull the chart into the RKE2-Charts repository. [Here](https://github.com/rancher/rke2-charts/pull/250) is an example PR. 
+A member from the RKE2 team can now pull the chart into the RKE2-Charts repository. [Here](https://github.com/rancher/rke2-charts/pull/250) is an example PR.
 
 ### Step 6: Create RKE2 PR
 

--- a/charts/rancher-vsphere-cpi/Chart.yaml
+++ b/charts/rancher-vsphere-cpi/Chart.yaml
@@ -1,14 +1,14 @@
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/display-name: vSphere CPI
-  catalog.cattle.io/kube-version: '>= 1.18.0-0 < 1.28.0-0'
+  catalog.cattle.io/kube-version: '>= 1.18.0-0 < 1.29.0-0'
   catalog.cattle.io/namespace: kube-system
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/rancher-version: '>= 2.8.0-0'
   catalog.cattle.io/release-name: vsphere-cpi
 apiVersion: v1
-appVersion: 1.27.0
+appVersion: 1.28.0
 description: vSphere Cloud Provider Interface (CPI)
 icon: https://charts.rancher.io/assets/logos/vsphere-cpi.svg
 keywords:
@@ -16,11 +16,9 @@ keywords:
 maintainers:
 - email: jiaqi.luo@suse.com
   name: Jiaqi Luo
-- email: anna.blendermann@suse.com
-  name: Andy Blendermann
 - email: brad.davidson@suse.com
   name: Brad Davidson
 name: rancher-vsphere-cpi
 sources:
 - https://github.com/kubernetes/cloud-provider-vsphere
-version: 1.6.0
+version: 1.7.0

--- a/charts/rancher-vsphere-cpi/values.yaml
+++ b/charts/rancher-vsphere-cpi/values.yaml
@@ -32,6 +32,11 @@ vCenter:
 # Supported versions can be found at:
 # https://github.com/kubernetes/cloud-provider-vsphere#compatibility-with-kubernetes
 versionOverrides:
+  - constraint: "~ 1.28"
+    values:
+      cloudControllerManager:
+        repository: rancher/mirrored-cloud-provider-vsphere-cpi-release-manager
+        tag: v1.28.0
   - constraint: "~ 1.27"
     values:
       cloudControllerManager:

--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -1,14 +1,14 @@
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/display-name: vSphere CSI
-  catalog.cattle.io/kube-version: '>= 1.20.0-0 < 1.28.0-0'
+  catalog.cattle.io/kube-version: '>= 1.20.0-0 < 1.29.0-0'
   catalog.cattle.io/namespace: kube-system
   catalog.cattle.io/os: linux,windows
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/rancher-version: '>= 2.8.0-0'
   catalog.cattle.io/release-name: vsphere-csi
 apiVersion: v1
-appVersion: 3.0.2-rancher2
+appVersion: 3.1.2-rancher1
 description: vSphere Cloud Storage Interface (CSI)
 icon: https://charts.rancher.io/assets/logos/vsphere-csi.svg
 keywords:
@@ -16,11 +16,9 @@ keywords:
 maintainers:
 - email: jiaqi.luo@suse.com
   name: Jiaqi Luo
-- email: anna.blendermann@suse.com
-  name: Andy Blendermann
 - email: brad.davidson@suse.com
   name: Brad Davidson
 name: rancher-vsphere-csi
 sources:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.0.2-rancher1
+version: 3.1.2-rancher1

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -102,7 +102,7 @@ csiNode:
   ## List of node taints to tolerate (requires Kubernetes >= 1.6)
   tolerations: []
   ## Optional additional labels to add to pods
-  podLabels: {} 
+  podLabels: {}
   prefixPath: ""
   prefixPathWindows: ""
   image:
@@ -144,8 +144,40 @@ global:
 # Supported versions can be found at:
 # https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/3.0/vmware-vsphere-csp-getting-started/GUID-D4AAD99E-9128-40CE-B89C-AD451DA8379D.html#kubernetes-versions-compatible-with-vsphere-container-storage-plugin-1
 versionOverrides:
+  # Versions from https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/v3.1.2/manifests/vanilla/vsphere-csi-driver.yaml
+  - constraint: ">= 1.26 < 1.29"
+    values:
+      csiController:
+        image:
+          repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
+          tag: v3.1.2
+          csiAttacher:
+            repository: rancher/mirrored-sig-storage-csi-attacher
+            tag: v4.3.0
+          csiResizer:
+            repository: rancher/mirrored-sig-storage-csi-resizer
+            tag: v1.8.0
+          livenessProbe:
+            repository: rancher/mirrored-sig-storage-livenessprobe
+            tag: v2.10.0
+          vsphereSyncer:
+            repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
+            tag: v3.1.2
+          csiProvisioner:
+            repository: rancher/mirrored-sig-storage-csi-provisioner
+            tag: v3.5.0
+      csiNode:
+        image:
+          repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
+          tag: v3.1.2
+          nodeDriverRegistrar:
+            repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
+            tag: v2.8.0
+          livenessProbe:
+            repository: rancher/mirrored-sig-storage-livenessprobe
+            tag: v2.10.0
   # Versions from https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/release-3.0/manifests/vanilla/vsphere-csi-driver.yaml
-  - constraint: ">= 1.24 < 1.28"
+  - constraint: ">= 1.24 < 1.26"
     values:
       csiController:
         image:

--- a/tests/unit/cpi_template_test.go
+++ b/tests/unit/cpi_template_test.go
@@ -29,6 +29,17 @@ func TestCPITemplateRenderedDaemonset(t *testing.T) {
 		args args
 	}{
 		{
+			name: "Kubernetes 1.28",
+			args: args{
+				values:        map[string]string{},
+				kubeVersion:   "1.28",
+				namespace:     "cpitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:   "cpitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:  cpiChart,
+				expectedImage: "rancher/mirrored-cloud-provider-vsphere-cpi-release-manager:v1.28.0",
+			},
+		},
+		{
 			name: "Kubernetes 1.27",
 			args: args{
 				values:        map[string]string{},

--- a/tests/unit/csi_template_test.go
+++ b/tests/unit/csi_template_test.go
@@ -29,6 +29,40 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 		args args
 	}{
 		{
+			name: "Kubernetes 1.28 Linux Only",
+			args: args{
+				values:         map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:    "1.28",
+				namespace:      "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:    "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:   csiChart,
+				windowsEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.8.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.1.2",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.10.0",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.28 Linux and Windows",
+			args: args{
+				values: map[string]string{
+					"vCenter.clusterId":         random.UniqueId(),
+					"csiWindowsSupport:enabled": "true",
+				},
+				kubeVersion:  "1.28",
+				namespace:    "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:  "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath: csiChart,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.8.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.1.2",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.10.0",
+				},
+			},
+		},
+		{
 			name: "Kubernetes 1.27 Linux Only",
 			args: args{
 				values:         map[string]string{"vCenter.clusterId": random.UniqueId()},
@@ -38,9 +72,9 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				chartRelPath:   csiChart,
 				windowsEnabled: false,
 				expectedImages: []string{
-					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.7.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.0.2",
-					"rancher/mirrored-sig-storage-livenessprobe:v2.9.0",
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.8.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.1.2",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.10.0",
 				},
 			},
 		},
@@ -56,9 +90,9 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				releaseName:  "csitest-" + strings.ToLower(random.UniqueId()),
 				chartRelPath: csiChart,
 				expectedImages: []string{
-					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.7.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.0.2",
-					"rancher/mirrored-sig-storage-livenessprobe:v2.9.0",
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.8.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.1.2",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.10.0",
 				},
 			},
 		},
@@ -72,9 +106,9 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				chartRelPath:   csiChart,
 				windowsEnabled: false,
 				expectedImages: []string{
-					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.7.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.0.2",
-					"rancher/mirrored-sig-storage-livenessprobe:v2.9.0",
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.8.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.1.2",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.10.0",
 				},
 			},
 		},
@@ -90,9 +124,9 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				releaseName:  "csitest-" + strings.ToLower(random.UniqueId()),
 				chartRelPath: csiChart,
 				expectedImages: []string{
-					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.7.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.0.2",
-					"rancher/mirrored-sig-storage-livenessprobe:v2.9.0",
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.8.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.1.2",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.10.0",
 				},
 			},
 		},
@@ -360,6 +394,46 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 		args args
 	}{
 		{
+			name: "Kubernetes 1.28 with CSI Resizer Enabled",
+			args: args{
+				values: map[string]string{
+					"vCenter.clusterId":                random.UniqueId(),
+					"csiController.csiResizer.enabled": "true",
+				},
+				kubeVersion:       "1.28",
+				namespace:         "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:       "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:      csiChart,
+				csiResizerEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-attacher:v4.3.0",
+					"rancher/mirrored-sig-storage-csi-resizer:v1.8.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.1.2",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.10.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.1.2",
+					"rancher/mirrored-sig-storage-csi-provisioner:v3.5.0",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.28",
+			args: args{
+				values:            map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:       "1.28",
+				namespace:         "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:       "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:      csiChart,
+				csiResizerEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-attacher:v4.3.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.1.2",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.10.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.1.2",
+					"rancher/mirrored-sig-storage-csi-provisioner:v3.5.0",
+				},
+			},
+		},
+		{
 			name: "Kubernetes 1.27 with CSI Resizer Enabled",
 			args: args{
 				values: map[string]string{
@@ -372,12 +446,12 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				chartRelPath:      csiChart,
 				csiResizerEnabled: false,
 				expectedImages: []string{
-					"rancher/mirrored-sig-storage-csi-attacher:v4.2.0",
-					"rancher/mirrored-sig-storage-csi-resizer:v1.7.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.0.2",
-					"rancher/mirrored-sig-storage-livenessprobe:v2.9.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.0.2",
-					"rancher/mirrored-sig-storage-csi-provisioner:v3.4.0",
+					"rancher/mirrored-sig-storage-csi-attacher:v4.3.0",
+					"rancher/mirrored-sig-storage-csi-resizer:v1.8.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.1.2",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.10.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.1.2",
+					"rancher/mirrored-sig-storage-csi-provisioner:v3.5.0",
 				},
 			},
 		},
@@ -391,11 +465,11 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				chartRelPath:      csiChart,
 				csiResizerEnabled: false,
 				expectedImages: []string{
-					"rancher/mirrored-sig-storage-csi-attacher:v4.2.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.0.2",
-					"rancher/mirrored-sig-storage-livenessprobe:v2.9.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.0.2",
-					"rancher/mirrored-sig-storage-csi-provisioner:v3.4.0",
+					"rancher/mirrored-sig-storage-csi-attacher:v4.3.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.1.2",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.10.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.1.2",
+					"rancher/mirrored-sig-storage-csi-provisioner:v3.5.0",
 				},
 			},
 		},
@@ -412,12 +486,12 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				chartRelPath:      csiChart,
 				csiResizerEnabled: false,
 				expectedImages: []string{
-					"rancher/mirrored-sig-storage-csi-attacher:v4.2.0",
-					"rancher/mirrored-sig-storage-csi-resizer:v1.7.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.0.2",
-					"rancher/mirrored-sig-storage-livenessprobe:v2.9.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.0.2",
-					"rancher/mirrored-sig-storage-csi-provisioner:v3.4.0",
+					"rancher/mirrored-sig-storage-csi-attacher:v4.3.0",
+					"rancher/mirrored-sig-storage-csi-resizer:v1.8.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.1.2",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.10.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.1.2",
+					"rancher/mirrored-sig-storage-csi-provisioner:v3.5.0",
 				},
 			},
 		},
@@ -431,11 +505,11 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				chartRelPath:      csiChart,
 				csiResizerEnabled: false,
 				expectedImages: []string{
-					"rancher/mirrored-sig-storage-csi-attacher:v4.2.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.0.2",
-					"rancher/mirrored-sig-storage-livenessprobe:v2.9.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.0.2",
-					"rancher/mirrored-sig-storage-csi-provisioner:v3.4.0",
+					"rancher/mirrored-sig-storage-csi-attacher:v4.3.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.1.2",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.10.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.1.2",
+					"rancher/mirrored-sig-storage-csi-provisioner:v3.5.0",
 				},
 			},
 		},
@@ -723,6 +797,20 @@ func TestCSITemplateRenderedControllerDeploymentArgs(t *testing.T) {
 		args args
 	}{
 		{
+			name: "Kubernetes 1.28",
+			args: args{
+				values:       map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:  "1.28",
+				namespace:    "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:  "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath: csiChart,
+				expectedArgs: []string{
+					"--fss-name=internal-feature-states.csi.vsphere.vmware.com",
+					"--fss-namespace=$(CSI_NAMESPACE)",
+				},
+			},
+		},
+		{
 			name: "Kubernetes 1.27",
 			args: args{
 				values:       map[string]string{"vCenter.clusterId": random.UniqueId()},
@@ -885,6 +973,20 @@ func TestCSITemplateRenderedNodeDaemonSetArgs(t *testing.T) {
 		name string
 		args args
 	}{
+		{
+			name: "Kubernetes 1.28",
+			args: args{
+				values:       map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:  "1.28",
+				namespace:    "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:  "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath: csiChart,
+				expectedArgs: []string{
+					"--fss-name=internal-feature-states.csi.vsphere.vmware.com",
+					"--fss-namespace=$(CSI_NAMESPACE)",
+				},
+			},
+		},
 		{
 			name: "Kubernetes 1.27",
 			args: args{


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] Chart version has been incremented (if necessary)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Mostly just image tag bumps to support k8s 1.28. Also includes minor version bump (not major).

Checked upstream charts to make sure there were no changes necessary on our end. 

<!-- New image, version bump. script update, etc etc -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->
Issues: 
- https://github.com/rancher/rancher/issues/43495
- https://github.com/rancher/rancher/issues/43494

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.