### PR TITLE
feat(storageclass.yaml): Add option for 'reclaimPolicy'

### DIFF
--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -21,4 +21,4 @@ maintainers:
 name: rancher-vsphere-csi
 sources:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.3.1-rancher1
+version: 3.3.1-rancher2

--- a/charts/rancher-vsphere-csi/templates/storageclass.yaml
+++ b/charts/rancher-vsphere-csi/templates/storageclass.yaml
@@ -6,6 +6,7 @@ metadata:
  annotations:
   storageclass.kubernetes.io/is-default-class: {{ .Values.storageClass.isDefault | quote }}
 provisioner: csi.vsphere.vmware.com
+reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}
 allowVolumeExpansion: {{ .Values.storageClass.allowVolumeExpansion }}
 parameters:
   {{- if .Values.storageClass.datastoreURL  }}

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -127,6 +127,7 @@ storageClass:
   isDefault: true
   storagePolicyName: ""
   datastoreURL: ""
+  reclaimPolicy: Delete
 
 global:
   cattle:


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] Chart version has been incremented (if necessary)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Feature: Add option for `reclaimPolicy` in `storageclass.yaml`.
This feature allow change default value for reclaimPolicy from Delete to Retain.

#### Linked Issues ####

None

#### Additional Notes ####
- Default value in `values.yaml` is set to `Delete`, so no breaking changes and fully compatibility.
- Tested on vSphere Client v. 8.0.2, K8S v1.27.12, provider RKE2.
- Tested with default reclaim policy (Delete) and with Retain policy.
- Helm lint

![Lint](https://github.com/rancher/vsphere-charts/assets/52672224/e90c87a3-20b5-457c-851d-03fe9f7e2560)

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.