### PR TITLE
feat(deployment/daemonset): Add option for resources

### DIFF
--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
   catalog.cattle.io/rancher-version: '>= 2.9.0-0'
   catalog.cattle.io/release-name: vsphere-csi
 apiVersion: v1
-appVersion: 3.3.1-rancher3
+appVersion: 3.3.1-rancher4
 description: vSphere Cloud Storage Interface (CSI)
 icon: https://charts.rancher.io/assets/logos/vsphere-csi.svg
 keywords:
@@ -21,4 +21,4 @@ maintainers:
 name: rancher-vsphere-csi
 sources:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.3.1-rancher3
+version: 3.3.1-rancher4

--- a/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
+++ b/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
@@ -96,6 +96,10 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
+          {{- with .Values.csiController.image.csiAttacher.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -114,6 +118,10 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
+          {{- with .Values.csiController.image.csiResizer.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -135,6 +143,10 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
+          {{- with .Values.csiController.image.csiSnapshotter.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
@@ -169,6 +181,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          {{- with .Values.csiController.image.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume
@@ -196,6 +212,10 @@ spec:
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
+          {{- with .Values.csiController.image.livenessProbe.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
@@ -225,6 +245,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          {{- with .Values.csiController.image.vsphereSyncer.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /etc/cloud
               name: vsphere-config-volume
@@ -248,6 +272,10 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
+          {{- with .Values.csiController.image.csiProvisioner.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
@@ -78,6 +78,10 @@ spec:
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
               value: {{ .Values.csiNode.prefixPath }}/var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
+          {{- with .Values.csiNode.image.nodeDriverRegistrar.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
@@ -122,6 +126,10 @@ spec:
                   fieldPath: metadata.namespace
             - name: NODEGETINFO_WATCH_TIMEOUT_MINUTES
               value: "1"
+          {{- with .Values.csiNode.image.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             privileged: true
             capabilities:
@@ -159,6 +167,10 @@ spec:
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
+          {{- with .Values.csiNode.image.livenessProbe.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -27,30 +27,87 @@ csiController:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
     tag: latest
     imagePullPolicy: ""
+    resources: {}
+    #resources:
+    # limits:
+    #   cpu: 100m
+    #   memory: 256Mi
+    # requests:
+    #   cpu: 50m
+    #   memory: 128Mi
     csiAttacher:
       repository: rancher/mirrored-sig-storage-csi-attacher
       tag: latest
       imagePullPolicy: ""
+      resources: {}
+      #resources:
+      # limits:
+      #   cpu: 100m
+      #   memory: 256Mi
+      # requests:
+      #   cpu: 50m
+      #   memory: 128Mi
     csiResizer:
       repository: rancher/mirrored-sig-storage-csi-resizer
       tag: latest
       imagePullPolicy: ""
+      resources: {}
+      #resources:
+      # limits:
+      #   cpu: 100m
+      #   memory: 256Mi
+      # requests:
+      #   cpu: 50m
+      #   memory: 128Mi
     livenessProbe:
       repository: rancher/mirrored-sig-storage-livenessprobe
       tag: latest
       imagePullPolicy: ""
+      resources: {}
+      #resources:
+      # limits:
+      #   cpu: 100m
+      #   memory: 256Mi
+      # requests:
+      #   cpu: 50m
+      #   memory: 128Mi
     vsphereSyncer:
       repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
       tag: latest
       imagePullPolicy: ""
+      resources: {}
+      #resources:
+      # limits:
+      #   cpu: 100m
+      #   memory: 256Mi
+      # requests:
+      #   cpu: 50m
+      #   memory: 128Mi
     csiProvisioner:
       repository: rancher/mirrored-sig-storage-csi-provisioner
       tag: latest
       imagePullPolicy: ""
+      resources: {}
+      #resources:
+      # limits:
+      #   cpu: 100m
+      #   memory: 256Mi
+      # requests:
+      #   cpu: 50m
+      #   memory: 128Mi
     csiSnapshotter:
       repository: rancher/mirrored-sig-storage-csi-snapshotter
       tag: latest
       imagePullPolicy: ""
+      resources: {}
+      #resources:
+      # limits:
+      #   cpu: 100m
+      #   memory: 256Mi
+      # requests:
+      #   cpu: 50m
+      #   memory: 128Mi
+
   ## Node labels for pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
@@ -121,14 +178,38 @@ csiNode:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
     tag: latest
     imagePullPolicy: ""
+    resources: {}
+    #resources:
+    # limits:
+    #   cpu: 100m
+    #   memory: 256Mi
+    # requests:
+    #   cpu: 50m
+    #   memory: 128Mi
     nodeDriverRegistrar:
       repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
       tag: latest
       imagePullPolicy: ""
+      resources: {}
+      #resources:
+      # limits:
+      #   cpu: 100m
+      #   memory: 256Mi
+      # requests:
+      #   cpu: 50m
+      #   memory: 128Mi
     livenessProbe:
       repository: rancher/mirrored-sig-storage-livenessprobe
       tag: latest
       imagePullPolicy: ""
+      resources: {}
+      #resources:
+      # limits:
+      #   cpu: 500m
+      #   memory: 256Mi
+      # requests:
+      #   cpu: 50m
+      #   memory: 128Mi
 
 storageClass:
   enabled: true


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [ ] Chart version has been incremented (if necessary)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####
- Add support for settings resources for all pods in `deployment` and `daemonset`.
- Using resource limits/requests is best practices and is recommended.
- Default values in `values.yaml` is blank for all images, so no breaking change and full compatibility is maintained

#### Linked Issues ####
None
#### Additional Notes ####

- Tested on vSphere Client v. 8.0.2, K8S v1.27.12, provider RKE2.
- Helm lint
![Screenshot from 2024-04-09 14-28-56](https://github.com/rancher/vsphere-charts/assets/52672224/221c4885-b626-435e-a1cf-8b7777a06da1)

**Importance notes**
- Version of Char has not been changed due to more PR
- `Limits` and `Requests` in `resources` comments are only for example. I don't recommended to use these values in production.

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.