### PR TITLE
feat(deployment/daemonset): Remove imagePullPolicy from charts

### DIFF
--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
   catalog.cattle.io/rancher-version: '>= 2.9.0-0'
   catalog.cattle.io/release-name: vsphere-csi
 apiVersion: v1
-appVersion: 3.3.1-rancher1
+appVersion: 3.3.1-rancher3
 description: vSphere Cloud Storage Interface (CSI)
 icon: https://charts.rancher.io/assets/logos/vsphere-csi.svg
 keywords:
@@ -21,4 +21,4 @@ maintainers:
 name: rancher-vsphere-csi
 sources:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.3.1-rancher2
+version: 3.3.1-rancher3

--- a/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
+++ b/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
@@ -85,6 +85,7 @@ spec:
       containers:
         - name: csi-attacher
           image: "{{ template "system_default_registry" . }}{{ .Values.csiController.image.csiAttacher.repository }}:{{ .Values.csiController.image.csiAttacher.tag }}"
+          imagePullPolicy: {{ .Values.csiController.image.csiAttacher.imagePullPolicy | quote }}
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -101,6 +102,7 @@ spec:
 {{- if .Values.csiController.csiResizer.enabled }}
         - name: csi-resizer
           image: "{{ template "system_default_registry" . }}{{ .Values.csiController.image.csiResizer.repository }}:{{ .Values.csiController.image.csiResizer.tag }}"
+          imagePullPolicy: {{ .Values.csiController.image.csiResizer.imagePullPolicy | quote }}
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -119,6 +121,7 @@ spec:
 {{- if .Values.blockVolumeSnapshot.enabled }}
         - name: csi-snapshotter
           image: "{{ template "system_default_registry" . }}{{ .Values.csiController.image.csiSnapshotter.repository }}:{{ .Values.csiController.image.csiSnapshotter.tag }}"
+          imagePullPolicy: {{ .Values.csiController.image.csiSnapshotter.imagePullPolicy | quote }}
           args:
             - "--v=4"
             - "--kube-api-qps=100"
@@ -138,13 +141,13 @@ spec:
 {{- end }}
         - name: vsphere-csi-controller
           image: "{{ template "system_default_registry" . }}{{ .Values.csiController.image.repository }}:{{ .Values.csiController.image.tag }}"
+          imagePullPolicy: {{ .Values.csiController.image.imagePullPolicy | quote }}
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
             {{- if semverCompare "< 1.24" $.Capabilities.KubeVersion.Version }}
             - "--use-gocsi=false"
             {{- end }}
-          imagePullPolicy: "Always"
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
@@ -189,6 +192,7 @@ spec:
             failureThreshold: 3
         - name: liveness-probe
           image: "{{ template "system_default_registry" . }}{{ .Values.csiController.image.livenessProbe.repository }}:{{ .Values.csiController.image.livenessProbe.tag }}"
+          imagePullPolicy: {{ .Values.csiController.image.livenessProbe.imagePullPolicy | quote }}
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -197,11 +201,11 @@ spec:
               mountPath: /csi
         - name: vsphere-syncer
           image: "{{ template "system_default_registry" . }}{{ .Values.csiController.image.vsphereSyncer.repository }}:{{ .Values.csiController.image.vsphereSyncer.tag }}"
+          imagePullPolicy: {{ .Values.csiController.image.vsphereSyncer.imagePullPolicy | quote }}
           args:
             - "--leader-election"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
-          imagePullPolicy: "Always"
           ports:
             - containerPort: 2113
               name: prometheus
@@ -227,6 +231,7 @@ spec:
               readOnly: true
         - name: csi-provisioner
           image: "{{ template "system_default_registry" . }}{{ .Values.csiController.image.csiProvisioner.repository }}:{{ .Values.csiController.image.csiProvisioner.tag }}"
+          imagePullPolicy: {{ .Values.csiController.image.csiProvisioner.imagePullPolicy | quote }}
           args:
             - "--v=4"
             - "--timeout=300s"

--- a/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
@@ -68,6 +68,7 @@ spec:
       containers:
         - name: node-driver-registrar
           image: "{{ template "system_default_registry" . }}{{ .Values.csiNode.image.nodeDriverRegistrar.repository }}:{{ .Values.csiNode.image.nodeDriverRegistrar.tag }}"
+          imagePullPolicy: {{ .Values.csiNode.image.nodeDriverRegistrar.imagePullPolicy | quote }}
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -91,13 +92,13 @@ spec:
             initialDelaySeconds: 3
         - name: vsphere-csi-node
           image: "{{ template "system_default_registry" . }}{{ .Values.csiNode.image.repository }}:{{ .Values.csiNode.image.tag }}"
+          imagePullPolicy: {{ .Values.csiNode.image.imagePullPolicy | quote }}
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
             {{- if semverCompare "< 1.24" $.Capabilities.KubeVersion.Version }}
             - "--use-gocsi=false"
             {{- end }}
-          imagePullPolicy: "Always"
           env:
             - name: NODE_NAME
               valueFrom:
@@ -154,6 +155,7 @@ spec:
             failureThreshold: 3
         - name: liveness-probe
           image: "{{ template "system_default_registry" . }}{{ .Values.csiNode.image.livenessProbe.repository }}:{{ .Values.csiNode.image.livenessProbe.tag }}"
+          imagePullPolicy: {{ .Values.csiNode.image.livenessProbe.imagePullPolicy | quote }}
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -26,24 +26,31 @@ csiController:
   image:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
     tag: latest
+    imagePullPolicy: ""
     csiAttacher:
       repository: rancher/mirrored-sig-storage-csi-attacher
       tag: latest
+      imagePullPolicy: ""
     csiResizer:
       repository: rancher/mirrored-sig-storage-csi-resizer
       tag: latest
+      imagePullPolicy: ""
     livenessProbe:
       repository: rancher/mirrored-sig-storage-livenessprobe
       tag: latest
+      imagePullPolicy: ""
     vsphereSyncer:
       repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
       tag: latest
+      imagePullPolicy: ""
     csiProvisioner:
       repository: rancher/mirrored-sig-storage-csi-provisioner
       tag: latest
+      imagePullPolicy: ""
     csiSnapshotter:
       repository: rancher/mirrored-sig-storage-csi-snapshotter
       tag: latest
+      imagePullPolicy: ""
   ## Node labels for pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
@@ -113,12 +120,15 @@ csiNode:
   image:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
     tag: latest
+    imagePullPolicy: ""
     nodeDriverRegistrar:
       repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
       tag: latest
+      imagePullPolicy: ""
     livenessProbe:
       repository: rancher/mirrored-sig-storage-livenessprobe
       tag: latest
+      imagePullPolicy: ""
 
 storageClass:
   enabled: true


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [ ] Chart version has been incremented (if necessary)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####
- Remove `ImagePullPolicy: "Always"` from `daemonset` and `deployment`

According to [documentation](https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting) if you specify version of image tag, automatically ImagePullPolicy is set to `IfNotPressent`.
And vice versa if you not specify version of image tag (keep latest) ImagePullPolicy is set to `Always`.

So keep ImagePullPolicy hard coded to `Always` in charts does not make sense.
It overrides to `Always` even if image tag is defined.

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####
- Helm lint

![Screenshot from 2024-04-09 15-07-19](https://github.com/rancher/vsphere-charts/assets/52672224/43285fc1-c5cc-4fbf-913a-e1cf569fcfc9)

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.