### PR TITLE
[DNM] add multi-vcenter-csi-topology flag to csi configmap

### DIFF
--- a/charts/rancher-vsphere-csi/templates/configmap.yaml
+++ b/charts/rancher-vsphere-csi/templates/configmap.yaml
@@ -16,6 +16,8 @@ data:
   "cnsmgr-suspend-create-volume": {{ .Values.cnsmgrSuspendCreateVolume.enabled | quote }}
   "topology-preferential-datastores": {{ .Values.topologyPreferentialDatastores.enabled | quote }}
   "max-pvscsi-targets-per-vm": {{ .Values.maxPvscsiTargetsPerVm.enabled | quote }}
+  # this one does not support being disabled but needs to be present, so we just have it set to true
+  "multi-vcenter-csi-topology": "true"
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com


### PR DESCRIPTION
# Issue: https://github.com/rancher/rancher/issues/45093

#### Pull Request Checklist ####

- [x] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] Chart version has been incremented (if necessary)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Adding a flag to the csi configmap due to a new required flag in 3.1.2

#### Linked Issues ####

N/A

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.

SURE-8151