### PR TITLE
introduce `multi-vcenter-csi-topology` config map option

### DIFF
--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
   catalog.cattle.io/rancher-version: '>= 2.8.0-0'
   catalog.cattle.io/release-name: vsphere-csi
 apiVersion: v1
-appVersion: 3.1.2-rancher2
+appVersion: 3.1.2-rancher3
 description: vSphere Cloud Storage Interface (CSI)
 icon: https://charts.rancher.io/assets/logos/vsphere-csi.svg
 keywords:

--- a/charts/rancher-vsphere-csi/templates/configmap.yaml
+++ b/charts/rancher-vsphere-csi/templates/configmap.yaml
@@ -16,6 +16,7 @@ data:
   "cnsmgr-suspend-create-volume": {{ .Values.cnsmgrSuspendCreateVolume.enabled | quote }}
   "topology-preferential-datastores": {{ .Values.topologyPreferentialDatastores.enabled | quote }}
   "max-pvscsi-targets-per-vm": {{ .Values.maxPvscsiTargetsPerVm.enabled | quote }}
+  "multi-vcenter-csi-topology": {{ .Values.multiVcenterCsiTopology.enabled | quote }}
 kind: ConfigMap
 metadata:
   name: internal-feature-states.csi.vsphere.vmware.com

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -96,6 +96,8 @@ topologyPreferentialDatastores:
   enabled: false
 maxPvscsiTargetsPerVm:
   enabled: false
+multiVcenterCsiTopology:
+  enabled: true
 
 csiNode:
   ## Node labels for pod assignment


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/45093
###### Supersedes: https://github.com/rancher/vsphere-charts/pull/73

#### Pull Request Checklist ####

- [x] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] Chart version has been incremented (if necessary)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

This is a copy of #73 with the nits addressed. Bumped the app version to `3.1.2-rancher3` and made sure that `multi-vcenter-csi-topology` is configurable via values.yaml

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.