### PR TITLE
Update `questions.yaml` to include multiVcenterCsiTopology variable

### DIFF
--- a/charts/rancher-vsphere-csi/questions.yaml
+++ b/charts/rancher-vsphere-csi/questions.yaml
@@ -83,6 +83,13 @@ questions:
     default: false
     group: Driver Configuration
 
+  - variable: multiVcenterCsiTopology.enabled
+    label: Enable Multi-vCenter-CSI-Topology
+    description: Enables the vSphere CSI Driver to operate on a topology-aware Kubernetes Cluster spread across multiple vCenter servers
+    type: boolean
+    default: true
+    group: Driver Configuration
+
   - variable: csiWindowsSupport.enabled
     label: Enable CSI Windows Support
     description: Enables Windows support.


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [ ] Chart version has been incremented (if necessary)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Updates `questions.yaml` to allow configuration of the `multiVcenterCsiTopology` variable defined in values.yaml. The description for the question comes directly from upstream, https://github.com/kubernetes-sigs/vsphere-csi-driver/milestone/6

#### Linked Issues ####

https://github.com/rancher/rancher/issues/45093

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.