### PR TITLE
Default `csiAuthCheck` to true

### DIFF
--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
   catalog.cattle.io/rancher-version: '>= 2.8.0-0'
   catalog.cattle.io/release-name: vsphere-csi
 apiVersion: v1
-appVersion: 3.1.2-rancher3
+appVersion: 3.1.2-rancher4
 description: vSphere Cloud Storage Interface (CSI)
 icon: https://charts.rancher.io/assets/logos/vsphere-csi.svg
 keywords:
@@ -21,4 +21,4 @@ maintainers:
 name: rancher-vsphere-csi
 sources:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.1.2-rancher3
+version: 3.1.2-rancher4

--- a/charts/rancher-vsphere-csi/questions.yaml
+++ b/charts/rancher-vsphere-csi/questions.yaml
@@ -45,7 +45,7 @@ questions:
   - variable: csiAuthCheck.enabled
     label: Enable authorization checks on operations involving datastores
     type: boolean
-    default: false
+    default: true
     group: Driver Configuration
 
   - variable: onlineVolumeExtend.enabled

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -67,7 +67,7 @@ csiController:
 csiMigration:
   enabled: false
 csiAuthCheck:
-  enabled: false
+  enabled: true
 onlineVolumeExtend:
   enabled: false
 triggerCsiFullsync:


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] Chart version has been incremented (if necessary)
- [x] That helm lint and pack run successfully on the chart.
- [ ] Deployment of the chart has been tested and verified that it functions as expected.
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Default settings change

#### Linked Issues ####

https://github.com/rancher/rancher/issues/45093

#### Additional Notes ####

Changes the default value of `csiAuthCheck` to ensure the chart works with the default value of `multiVcenterCsiTopology`

I've bumped to rancher4 since it looks like rancher3 was pulled through to rke2 (though it was not released), if this should stay at rancher3 let me know

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.