### PR TITLE
Update CSI images for K8s 1.30 support

### DIFF
--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -1,14 +1,14 @@
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/display-name: vSphere CSI
-  catalog.cattle.io/kube-version: '>= 1.20.0-0 < 1.30.0-0'
+  catalog.cattle.io/kube-version: '>= 1.20.0-0 < 1.31.0-0'
   catalog.cattle.io/namespace: kube-system
   catalog.cattle.io/os: linux,windows
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/rancher-version: '>= 2.9.0-0'
   catalog.cattle.io/release-name: vsphere-csi
 apiVersion: v1
-appVersion: 3.2.0-rancher1
+appVersion: 3.3.0-rancher1
 description: vSphere Cloud Storage Interface (CSI)
 icon: https://charts.rancher.io/assets/logos/vsphere-csi.svg
 keywords:
@@ -21,4 +21,4 @@ maintainers:
 name: rancher-vsphere-csi
 sources:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.2.0-rancher1
+version: 3.3.0-rancher1

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -149,8 +149,43 @@ global:
 # Supported versions can be found at:
 # https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/3.0/vmware-vsphere-csp-getting-started/GUID-D4AAD99E-9128-40CE-B89C-AD451DA8379D.html#kubernetes-versions-compatible-with-vsphere-container-storage-plugin-1
 versionOverrides:
+  # Versions from https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/v3.3.0/manifests/vanilla/vsphere-csi-driver.yaml
+  - constraint: ">= 1.28 < 1.31"
+    values:
+      csiController:
+        image:
+          repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
+          tag: v3.3.0
+          csiAttacher:
+            repository: rancher/mirrored-sig-storage-csi-attacher
+            tag: v4.5.1
+          csiResizer:
+            repository: rancher/mirrored-sig-storage-csi-resizer
+            tag: v1.10.1
+          livenessProbe:
+            repository: rancher/mirrored-sig-storage-livenessprobe
+            tag: v2.12.0
+          vsphereSyncer:
+            repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
+            tag: v3.3.0
+          csiProvisioner:
+            repository: rancher/mirrored-sig-storage-csi-provisioner
+            tag: v4.0.1
+          csiSnapshotter:
+            repository: rancher/mirrored-sig-storage-csi-snapshotter
+            tag: v7.0.2
+      csiNode:
+        image:
+          repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
+          tag: v3.3.0
+          nodeDriverRegistrar:
+            repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
+            tag: v2.10.1
+          livenessProbe:
+            repository: rancher/mirrored-sig-storage-livenessprobe
+            tag: v2.12.0
   # Versions from https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/v3.2.0/manifests/vanilla/vsphere-csi-driver.yaml
-  - constraint: ">= 1.27 < 1.30"
+  - constraint: ">= 1.27 < 1.28"
     values:
       csiController:
         image:

--- a/tests/unit/csi_template_test.go
+++ b/tests/unit/csi_template_test.go
@@ -29,6 +29,40 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 		args args
 	}{
 		{
+			name: "Kubernetes 1.30 Linux Only",
+			args: args{
+				values:         map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:    "1.30",
+				namespace:      "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:    "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:   csiChart,
+				windowsEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.10.1",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.3.0",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.12.0",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.30 Linux and Windows",
+			args: args{
+				values: map[string]string{
+					"vCenter.clusterId":         random.UniqueId(),
+					"csiWindowsSupport:enabled": "true",
+				},
+				kubeVersion:  "1.30",
+				namespace:    "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:  "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath: csiChart,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.10.1",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.3.0",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.12.0",
+				},
+			},
+		},
+		{
 			name: "Kubernetes 1.29 Linux Only",
 			args: args{
 				values:         map[string]string{"vCenter.clusterId": random.UniqueId()},
@@ -38,8 +72,8 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				chartRelPath:   csiChart,
 				windowsEnabled: false,
 				expectedImages: []string{
-					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.10.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.2.0",
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.10.1",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.3.0",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.12.0",
 				},
 			},
@@ -56,8 +90,8 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				releaseName:  "csitest-" + strings.ToLower(random.UniqueId()),
 				chartRelPath: csiChart,
 				expectedImages: []string{
-					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.10.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.2.0",
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.10.1",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.3.0",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.12.0",
 				},
 			},
@@ -72,8 +106,8 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				chartRelPath:   csiChart,
 				windowsEnabled: false,
 				expectedImages: []string{
-					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.10.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.2.0",
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.10.1",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.3.0",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.12.0",
 				},
 			},
@@ -90,8 +124,8 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				releaseName:  "csitest-" + strings.ToLower(random.UniqueId()),
 				chartRelPath: csiChart,
 				expectedImages: []string{
-					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.10.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.2.0",
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.10.1",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.3.0",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.12.0",
 				},
 			},
@@ -428,6 +462,69 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 		args args
 	}{
 		{
+			name: "Kubernetes 1.30 with Block Snapshotter Enabled",
+			args: args{
+				values: map[string]string{
+					"vCenter.clusterId":           random.UniqueId(),
+					"blockVolumeSnapshot.enabled": "true",
+				},
+				kubeVersion:       "1.30",
+				namespace:         "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:       "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:      csiChart,
+				csiResizerEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-attacher:v4.5.1",
+					"rancher/mirrored-sig-storage-csi-snapshotter:v7.0.2",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.3.0",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.12.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.3.0",
+					"rancher/mirrored-sig-storage-csi-provisioner:v4.0.1",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.30 with CSI Resizer Enabled",
+			args: args{
+				values: map[string]string{
+					"vCenter.clusterId":                random.UniqueId(),
+					"csiController.csiResizer.enabled": "true",
+				},
+				kubeVersion:       "1.30",
+				namespace:         "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:       "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:      csiChart,
+				csiResizerEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-attacher:v4.5.1",
+					"rancher/mirrored-sig-storage-csi-resizer:v1.10.1",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.3.0",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.12.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.3.0",
+					"rancher/mirrored-sig-storage-csi-provisioner:v4.0.1",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.30",
+			args: args{
+				values:            map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:       "1.30",
+				namespace:         "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:       "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:      csiChart,
+				csiResizerEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-attacher:v4.5.1",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.3.0",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.12.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.3.0",
+					"rancher/mirrored-sig-storage-csi-provisioner:v4.0.1",
+				},
+			},
+		},
+		//
+		{
 			name: "Kubernetes 1.29 with Block Snapshotter Enabled",
 			args: args{
 				values: map[string]string{
@@ -440,12 +537,12 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				chartRelPath:      csiChart,
 				csiResizerEnabled: false,
 				expectedImages: []string{
-					"rancher/mirrored-sig-storage-csi-attacher:v4.5.0",
-					"rancher/mirrored-sig-storage-csi-snapshotter:v7.0.1",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.2.0",
+					"rancher/mirrored-sig-storage-csi-attacher:v4.5.1",
+					"rancher/mirrored-sig-storage-csi-snapshotter:v7.0.2",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.3.0",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.12.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.2.0",
-					"rancher/mirrored-sig-storage-csi-provisioner:v4.0.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.3.0",
+					"rancher/mirrored-sig-storage-csi-provisioner:v4.0.1",
 				},
 			},
 		},
@@ -462,12 +559,12 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				chartRelPath:      csiChart,
 				csiResizerEnabled: false,
 				expectedImages: []string{
-					"rancher/mirrored-sig-storage-csi-attacher:v4.5.0",
-					"rancher/mirrored-sig-storage-csi-resizer:v1.10.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.2.0",
+					"rancher/mirrored-sig-storage-csi-attacher:v4.5.1",
+					"rancher/mirrored-sig-storage-csi-resizer:v1.10.1",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.3.0",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.12.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.2.0",
-					"rancher/mirrored-sig-storage-csi-provisioner:v4.0.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.3.0",
+					"rancher/mirrored-sig-storage-csi-provisioner:v4.0.1",
 				},
 			},
 		},
@@ -481,11 +578,11 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				chartRelPath:      csiChart,
 				csiResizerEnabled: false,
 				expectedImages: []string{
-					"rancher/mirrored-sig-storage-csi-attacher:v4.5.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.2.0",
+					"rancher/mirrored-sig-storage-csi-attacher:v4.5.1",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.3.0",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.12.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.2.0",
-					"rancher/mirrored-sig-storage-csi-provisioner:v4.0.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.3.0",
+					"rancher/mirrored-sig-storage-csi-provisioner:v4.0.1",
 				},
 			},
 		},
@@ -502,12 +599,12 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				chartRelPath:      csiChart,
 				csiResizerEnabled: false,
 				expectedImages: []string{
-					"rancher/mirrored-sig-storage-csi-attacher:v4.5.0",
-					"rancher/mirrored-sig-storage-csi-snapshotter:v7.0.1",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.2.0",
+					"rancher/mirrored-sig-storage-csi-attacher:v4.5.1",
+					"rancher/mirrored-sig-storage-csi-snapshotter:v7.0.2",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.3.0",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.12.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.2.0",
-					"rancher/mirrored-sig-storage-csi-provisioner:v4.0.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.3.0",
+					"rancher/mirrored-sig-storage-csi-provisioner:v4.0.1",
 				},
 			},
 		},
@@ -524,12 +621,12 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				chartRelPath:      csiChart,
 				csiResizerEnabled: false,
 				expectedImages: []string{
-					"rancher/mirrored-sig-storage-csi-attacher:v4.5.0",
-					"rancher/mirrored-sig-storage-csi-resizer:v1.10.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.2.0",
+					"rancher/mirrored-sig-storage-csi-attacher:v4.5.1",
+					"rancher/mirrored-sig-storage-csi-resizer:v1.10.1",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.3.0",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.12.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.2.0",
-					"rancher/mirrored-sig-storage-csi-provisioner:v4.0.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.3.0",
+					"rancher/mirrored-sig-storage-csi-provisioner:v4.0.1",
 				},
 			},
 		},
@@ -543,11 +640,11 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				chartRelPath:      csiChart,
 				csiResizerEnabled: false,
 				expectedImages: []string{
-					"rancher/mirrored-sig-storage-csi-attacher:v4.5.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.2.0",
+					"rancher/mirrored-sig-storage-csi-attacher:v4.5.1",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.3.0",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.12.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.2.0",
-					"rancher/mirrored-sig-storage-csi-provisioner:v4.0.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.3.0",
+					"rancher/mirrored-sig-storage-csi-provisioner:v4.0.1",
 				},
 			},
 		},
@@ -1003,6 +1100,20 @@ func TestCSITemplateRenderedControllerDeploymentArgs(t *testing.T) {
 		args args
 	}{
 		{
+			name: "Kubernetes 1.30",
+			args: args{
+				values:       map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:  "1.30",
+				namespace:    "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:  "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath: csiChart,
+				expectedArgs: []string{
+					"--fss-name=internal-feature-states.csi.vsphere.vmware.com",
+					"--fss-namespace=$(CSI_NAMESPACE)",
+				},
+			},
+		},
+		{
 			name: "Kubernetes 1.29",
 			args: args{
 				values:       map[string]string{"vCenter.clusterId": random.UniqueId()},
@@ -1193,6 +1304,20 @@ func TestCSITemplateRenderedNodeDaemonSetArgs(t *testing.T) {
 		name string
 		args args
 	}{
+		{
+			name: "Kubernetes 1.30",
+			args: args{
+				values:       map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:  "1.30",
+				namespace:    "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:  "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath: csiChart,
+				expectedArgs: []string{
+					"--fss-name=internal-feature-states.csi.vsphere.vmware.com",
+					"--fss-namespace=$(CSI_NAMESPACE)",
+				},
+			},
+		},
 		{
 			name: "Kubernetes 1.29",
 			args: args{


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] Chart version has been incremented (if necessary)
- [ ] That helm lint and pack run successfully on the chart.
- [ ] Deployment of the chart has been tested and verified that it functions as expected.
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

- Images has been bumped for vsphere-csi  support k8s 1.30.

#### Linked Issues ####

- https://github.com/rancher/rancher/issues/45747

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.