### PR TITLE
fix kube-version annotation to reflect #84 changes

### DIFF
--- a/charts/rancher-vsphere-cpi/Chart.yaml
+++ b/charts/rancher-vsphere-cpi/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/display-name: vSphere CPI
-  catalog.cattle.io/kube-version: '>= 1.18.0-0 < 1.31.0-0'
+  catalog.cattle.io/kube-version: '>= 1.27.0-0 < 1.31.0-0'
   catalog.cattle.io/namespace: kube-system
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux,windows

--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/display-name: vSphere CSI
-  catalog.cattle.io/kube-version: '>= 1.20.0-0 < 1.31.0-0'
+  catalog.cattle.io/kube-version: '>= 1.27.0-0 < 1.31.0-0'
   catalog.cattle.io/namespace: kube-system
   catalog.cattle.io/os: linux,windows
   catalog.cattle.io/permits-os: linux,windows


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] Chart version has been incremented (if necessary)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

<!-- New image, version bump. script update, etc etc -->
Fixing `kube-version` annotation to reflect the rest of the chart to rancher. I missed this in #84 

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->
https://github.com/rancher/rancher/issues/46146

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.