### PR TITLE
Add dual-stack support to vSphere CPI

### DIFF
--- a/charts/rancher-vsphere-cpi/questions.yaml
+++ b/charts/rancher-vsphere-cpi/questions.yaml
@@ -4,14 +4,14 @@ questions:
     description: IP address or FQDN of the vCenter
     type: string
     required: true
-    group: Configuration
+    group: vCenter
 
   - variable: vCenter.datacenters
     description: Comma-separated list of paths to data centers. E.g "<dc1-path>, <dc2-path>, ..."
     label: Data Centers
     type: string
     required: true
-    group: Configuration
+    group: vCenter
 
   - variable: vCenter.credentialsSecret.generate
     label: Generate Credential's Secret
@@ -19,44 +19,92 @@ questions:
     type: boolean
     default: true
     required: true
-    group: Configuration
+    group: vCenter
     show_subquestion_if: true
     subquestions:
       - variable: vCenter.username
         label: Username
         description: Username for vCenter
         type: string
-        group: Configuration
+        group: vCenter
       - variable: vCenter.password
         label: Password
         description: Password for vCenter
         type: password
-        group: Configuration
+        group: vCenter
 
   - variable: vCenter.credentialsSecret.name
     label: Credential's Secret Name
     description: Name of the secret with the vSphere credentials (Will not be visible in the API. More info in the README)
     default: "vsphere-cpi-creds"
     type: string
-    group: Configuration
+    group: vCenter
     show_if: "vCenter.credentialsSecret.generate=false"
 
   - variable: vCenter.labels.generate
     label: Define vSphere Tags
-    description: "vSphere Tags used to determine the zone and region of a Kubernetes node. This labels will be propagated to NodeLabels"
+    description: "vSphere Tags used to determine the zone and region of a Kubernetes node. This labels will be propagated to NodeLabels."
     type: boolean
     default: false
     required: true
-    group: Configuration
+    group: vCenter
     show_subquestion_if: true
     subquestions:
       - variable: vCenter.labels.region
         label: Region
         description: vSphere tag which will used to define regions. e.g. eu-central
         type: string
-        group: Configuration
+        group: vCenter
       - variable: vCenter.labels.zone
         label: Zone
         description: vSphere tag which will used to define availability zones
         type: string
-        group: Configuration
+        group: vCenter
+
+  - variable: global.ipFamily
+    label: Node Address IP Family
+    description: "The IP families of the address(es) to be assigned to the Node. The first selected family will be the Primary. Separate multiple families with a comma. Valid options are 'ipv4' and 'ipv6'."
+    type: string
+    default: "ipv4"
+    required: false
+    group: Global
+
+  - variable: nodesEnable
+    label: Node address selection filters
+    description: "Define the way that IP addresses are selected to be assigned to the Kubernetes Node"
+    type: boolean
+    default: false
+    required: false
+    group: Nodes
+    show_subquestion_if: true
+    subquestions:
+      - variable: nodes.internalNetworkSubnetCidr
+        label: Internal Network CIDR
+        description: "The vSphere cloud provider will select the first address that falls within the provided subnet and assign that value to the Internal IP for the node."
+        type: string
+        group: Nodes
+      - variable: nodes.externalNetworkSubnetCidr
+        label: External Network CIDR
+        description: "The vSphere cloud provider will select the first address that falls within the provided subnet and assign that value to the External IP for the node."
+        type: string
+        group: Nodes
+      - variable: nodes.internalVmNetworkName
+        label: Internal VM Network Name
+        description: "The vSphere cloud provider will select the first address found in the VM network matching the provided name and assign that value to the Internal IP for the node."
+        type: string
+        group: Nodes
+      - variable: nodes.externalVmNetworkName
+        label: External VM Network Name
+        description: "The vSphere cloud provider will select the first address found in the VM network matching the provided name and assign that value to the External IP for the node."
+        type: string
+        group: Nodes
+      - variable: nodes.excludeInternalNetworkSubnetCidr
+        label: Exclude Internal Network CIDR
+        description: "The vSphere cloud provider will never select addresses for the Internal IP that fall within the provided subnet ranges. This configuration has the highest precedence."
+        type: string
+        group: Nodes
+      - variable: nodes.excludeExternalNetworkSubnetCidr
+        label: Exclude External Network CIDR
+        description: "The vSphere cloud provider will never select addresses for the External IP that fall within the provided subnet ranges. This configuration has the highest precedence."
+        type: string
+        group: Nodes

--- a/charts/rancher-vsphere-cpi/templates/configmap.yaml
+++ b/charts/rancher-vsphere-cpi/templates/configmap.yaml
@@ -10,13 +10,16 @@ metadata:
 data:
   vsphere.yaml: |
     # Global properties in this section will be used for all specified vCenters unless overriden in VirtualCenter section.
-    {{ with .Values.vCenter }}
     global:
-      secretName: {{ .credentialsSecret.name | quote }}
+      secretName: {{ .Values.vCenter.credentialsSecret.name | quote }}
       secretNamespace: {{ $.Release.Namespace | quote }}
-      port: {{ .port }}
-      insecureFlag: {{ .insecureFlag }}
-
+      port: {{ .Values.vCenter.port }}
+      insecureFlag: {{ .Values.vCenter.insecureFlag }}
+      {{- with .Values.global.ipFamily }}
+      ipFamily:
+        {{- splitList "," . | toYaml | nindent 8 }}
+      {{- end }}
+    {{ with .Values.vCenter }}
     # vcenter section
     vcenter:
       {{ .host | quote }}:
@@ -29,5 +32,11 @@ data:
     labels:
       region: {{ .labels.region | quote }}
       zone: {{ .labels.zone | quote }}
+    {{- end }}
+    {{- end }}
+    {{- if .Values.nodesEnable }}
+    {{- with .Values.nodes }}
+    nodes:
+    {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- end }}

--- a/charts/rancher-vsphere-cpi/templates/daemonset.yaml
+++ b/charts/rancher-vsphere-cpi/templates/daemonset.yaml
@@ -102,6 +102,16 @@ spec:
           resources:
             requests:
               cpu: 200m
+          {{- if or (.Values.cloudControllerManager.env) (.Values.global.ipFamily) }}
+          env:
+          {{- if .Values.global.ipFamily }}
+            - name: ENABLE_ALPHA_DUAL_STACK
+              value: "true"
+          {{- end }}
+          {{- with .Values.cloudControllerManager.env }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
       hostNetwork: true
       volumes:
       - name: vsphere-config-volume

--- a/charts/rancher-vsphere-cpi/values.yaml
+++ b/charts/rancher-vsphere-cpi/values.yaml
@@ -9,11 +9,22 @@ vCenter:
     name: "vsphere-cpi-creds"
     generate: true
 
-# vSphere Tags used to determine the zone and region of a Kubernetes node. This labels will be propagated to NodeLabels
+  # vSphere Tags used to determine the zone and region of a Kubernetes node. This labels will be propagated to NodeLabels
   labels:
     region: "k8s-region"
     zone: "k8s-zone"
     generate: false
+
+# Nodes defines the way that the Node IPs are selected from the addresses assigned to the Node in kube-api
+# See https://github.com/kubernetes/cloud-provider-vsphere/blob/master/docs/book/cloud_config.md#nodes for details
+nodesEnable: false
+nodes:
+  internalNetworkSubnetCidr: ""
+  externalNetworkSubnetCidr: ""
+  internalVmNetworkName: ""
+  externalVmNetworkName: ""
+  excludeInternalNetworkSubnetCidr: ""
+  excludeExternalNetworkSubnetCidr: ""
 
 # A list of Semver constraint strings (defined by https://github.com/Masterminds/semver) and values.yaml overrides.
 #
@@ -67,7 +78,10 @@ cloudControllerManager:
   podLabels: {}
   rbac:
     enabled: true
+  env: []
 
 global:
   cattle:
     systemDefaultRegistry: ""
+  # Set the IP Family to set Node addresses for (ipv4 or ipv6 or dual-stack, defaults to ipv4 only)
+  ipFamily: ""


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [ ] Chart version has been incremented (if necessary)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Cilium >= 1.16.0 fails when deployed as dual stack as the nodes will not have IPv6 addresses, the CPI supports adding both IPv4 and IPv6 addresses to nodes but required an feature toggle env var to be specified.

This PR will allow the `ENABLE_ALPHA_DUAL_STACK` env to be set and enable both v4 and v6 address families.

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.