### PR TITLE
Add question for CSI volume snapshot support

### DIFF
--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
   catalog.cattle.io/rancher-version: '>= 2.9.0-0'
   catalog.cattle.io/release-name: vsphere-csi
 apiVersion: v1
-appVersion: 3.3.1-rancher5
+appVersion: 3.3.1-rancher6
 description: vSphere Cloud Storage Interface (CSI)
 icon: https://charts.rancher.io/assets/logos/vsphere-csi.svg
 keywords:
@@ -21,4 +21,4 @@ maintainers:
 name: rancher-vsphere-csi
 sources:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.3.1-rancher5
+version: 3.3.1-rancher6

--- a/charts/rancher-vsphere-csi/questions.yaml
+++ b/charts/rancher-vsphere-csi/questions.yaml
@@ -111,6 +111,13 @@ questions:
     default: false
     group: Storage
 
+  - variable: blockVolumeSnapshot.enabled
+    label: Enable CSI Volume Snapshots
+    description: Enables CSI Snapshot support for vSphere PVs
+    type: boolean
+    default: false
+    group: Storage
+
   - variable: storageClass.enabled
     default: true
     label: Create Storage Class


### PR DESCRIPTION
#### Pull Request Checklist ####


- [x] Chart version has been incremented (if necessary)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.

#### Types of Change ####

question

#### Linked Issues ####

* https://github.com/rancher/vsphere-charts/issues/67

#### Additional Notes ####

Not sure why we don't already have a question for this

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.