### PR TITLE
Add option to questions.yaml for both csi and cpi to switch secret management to Rancher

### DIFF
--- a/charts/rancher-vsphere-cpi/questions.yaml
+++ b/charts/rancher-vsphere-cpi/questions.yaml
@@ -22,6 +22,11 @@ questions:
     group: vCenter
     show_subquestion_if: true
     subquestions:
+      - variable:    vCenter.credentialsSecret.rancherManaged
+        label:       Manage generated secret via Rancher
+        description: Rancher hosts the secret and synchronizes it to the target cluster
+        type:        boolean
+        group: vCenter
       - variable: vCenter.username
         label: Username
         description: Username for vCenter

--- a/charts/rancher-vsphere-cpi/templates/secret.yaml
+++ b/charts/rancher-vsphere-cpi/templates/secret.yaml
@@ -1,3 +1,4 @@
+# Any changes should be mirrored by the UI when it creates it's version of the secret
 {{- if .Values.vCenter.credentialsSecret.generate -}}
 apiVersion: v1
 kind: Secret

--- a/charts/rancher-vsphere-cpi/values.yaml
+++ b/charts/rancher-vsphere-cpi/values.yaml
@@ -8,6 +8,8 @@ vCenter:
   credentialsSecret:
     name: "vsphere-cpi-creds"
     generate: true
+    # Only applicable when installed via Rancher Cluster Management
+    rancherManaged: false
 
   # vSphere Tags used to determine the zone and region of a Kubernetes node. This labels will be propagated to NodeLabels
   labels:

--- a/charts/rancher-vsphere-csi/questions.yaml
+++ b/charts/rancher-vsphere-csi/questions.yaml
@@ -8,6 +8,11 @@ questions:
     group: vCenter Configuration
     show_subquestion_if: true
     subquestions:
+      - variable:    vCenter.configSecret.rancherManaged
+        label:       Manage generated secret via Rancher
+        description: Rancher hosts the secret and synchronizes it to the target cluster
+        type:        boolean
+
       - variable: vCenter.host
         label: vCenter Host
         description: IP address or FQDN of the vCenter

--- a/charts/rancher-vsphere-csi/templates/secret.yaml
+++ b/charts/rancher-vsphere-csi/templates/secret.yaml
@@ -1,3 +1,4 @@
+# Any changes should be mirrored by the UI when it creates it's version of the secret
 {{- if .Values.vCenter.configSecret.generate -}}
 apiVersion: v1
 kind: Secret

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -9,6 +9,9 @@ vCenter:
   configSecret:
     name: "vsphere-config-secret"
     generate: true
+    # Only applicable when installed via Rancher Cluster Management
+    rancherManaged: false
+    # Any changes should be mirrored by the UI when it creates it's version of the secret
     configTemplate: |
       [Global]
       cluster-id = {{ required ".Values.vCenter.clusterId must be provided" (default .Values.vCenter.clusterId .Values.global.cattle.clusterId) | quote }}


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [ ] Chart version has been incremented (if necessary)
  - Is this done at the end of a release covering all changes within that release, if not is the pattern to bump both app and chart version?
- [x] That helm lint and pack run successfully on the chart.
- [ ] Deployment of the chart has been tested and verified that it functions as expected.
  - Bit tricky to do for use case, can this be skipped?
- [x] Changes to scripting or CI config have been tested to the best of your ability (not applicable)

#### Types of Change ####
- Add bool questions to both csi and cpi questions.yaml to offer secret management via Rancher
- When true UI creates the secret
- When false (default) the legacy behaviour of the secret created via helm is used


#### Linked Issues ####

- https://github.com/rancher/dashboard/issues/11892
- https://github.com/rancher/dashboard/issues/11920

#### Additional Notes ####
- Required for 2.8.9, 2.9.3 and 2.10.0. 
<!-- Any additional details / test results / etc -->

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.