### PR TITLE
feat(logging): add support for passing additional CSI container args

### DIFF
--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
   catalog.cattle.io/rancher-version: '>= 2.9.0-0'
   catalog.cattle.io/release-name: vsphere-csi
 apiVersion: v1
-appVersion: 3.3.1-rancher6
+appVersion: 3.3.1-rancher7
 description: vSphere Cloud Storage Interface (CSI)
 icon: https://charts.rancher.io/assets/logos/vsphere-csi.svg
 keywords:
@@ -21,4 +21,4 @@ maintainers:
 name: rancher-vsphere-csi
 sources:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.3.1-rancher6
+version: 3.3.1-rancher7

--- a/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
+++ b/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
@@ -93,7 +93,7 @@ spec:
             - "--leader-election"
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
-            - "--text=json"
+            - "--logging-format={{ .Values.csiController.image.csiAttacher.logFormat }}"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -116,7 +116,7 @@ spec:
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
             - "--leader-election"
-            - "--text=json"
+            - "--logging-format={{ .Values.csiController.image.csiResizer.logFormat }}"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -142,7 +142,6 @@ spec:
             - "--leader-election-lease-duration=120s"
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
-            - "--text=json"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -163,7 +162,6 @@ spec:
             {{- if semverCompare "< 1.24" $.Capabilities.KubeVersion.Version }}
             - "--use-gocsi=false"
             {{- end }}
-            - "--text=json"
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
@@ -216,7 +214,7 @@ spec:
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
-            - "--text=json"
+            - "--logging-format={{ .Values.csiController.image.livenessProbe.logFormat }}"
           {{- with .Values.csiController.image.livenessProbe.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -231,7 +229,6 @@ spec:
             - "--leader-election"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
-            - "--text=json"
           ports:
             - containerPort: 2113
               name: prometheus
@@ -270,7 +267,6 @@ spec:
             - "--kube-api-burst=100"
             - "--leader-election"
             - "--default-fstype=ext4"
-            - "--text=json"
             {{- if .Values.topology.enabled }}
             # needed only for topology aware setup
             - "--feature-gates=Topology=true"

--- a/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
+++ b/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
@@ -93,6 +93,7 @@ spec:
             - "--leader-election"
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
+            - "--text=json"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -115,6 +116,7 @@ spec:
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
             - "--leader-election"
+            - "--text=json"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -140,6 +142,7 @@ spec:
             - "--leader-election-lease-duration=120s"
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
+            - "--text=json"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -160,6 +163,7 @@ spec:
             {{- if semverCompare "< 1.24" $.Capabilities.KubeVersion.Version }}
             - "--use-gocsi=false"
             {{- end }}
+            - "--text=json"
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
@@ -212,6 +216,7 @@ spec:
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
+            - "--text=json"
           {{- with .Values.csiController.image.livenessProbe.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -226,6 +231,7 @@ spec:
             - "--leader-election"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
+            - "--text=json"
           ports:
             - containerPort: 2113
               name: prometheus
@@ -264,6 +270,7 @@ spec:
             - "--kube-api-burst=100"
             - "--leader-election"
             - "--default-fstype=ext4"
+            - "--text=json"
             {{- if .Values.topology.enabled }}
             # needed only for topology aware setup
             - "--feature-gates=Topology=true"

--- a/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
+++ b/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
@@ -93,7 +93,9 @@ spec:
             - "--leader-election"
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
-            - "--logging-format={{ .Values.csiController.image.csiAttacher.logFormat }}"
+            {{- range .Values.csiController.image.csiAttacher.additionalArgs }}
+            - {{ . }}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -116,7 +118,9 @@ spec:
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
             - "--leader-election"
-            - "--logging-format={{ .Values.csiController.image.csiResizer.logFormat }}"
+            {{- range .Values.csiController.image.csiResizer.additionalArgs }}
+            - {{ . }}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -214,7 +218,9 @@ spec:
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
-            - "--logging-format={{ .Values.csiController.image.livenessProbe.logFormat }}"
+            {{- range .Values.csiController.image.livenessProbe.additionalArgs }}
+            - {{ . }}
+            {{- end }}
           {{- with .Values.csiController.image.livenessProbe.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
+++ b/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
@@ -94,7 +94,7 @@ spec:
             - "--kube-api-qps=100"
             - "--kube-api-burst=100"
             {{- range .Values.csiController.image.csiAttacher.additionalArgs }}
-            - {{ . }}
+            - {{ . | quote }}
             {{- end }}
           env:
             - name: ADDRESS
@@ -119,7 +119,7 @@ spec:
             - "--kube-api-burst=100"
             - "--leader-election"
             {{- range .Values.csiController.image.csiResizer.additionalArgs }}
-            - {{ . }}
+            - {{ . | quote }}
             {{- end }}
           env:
             - name: ADDRESS
@@ -146,6 +146,9 @@ spec:
             - "--leader-election-lease-duration=120s"
             - "--leader-election-renew-deadline=60s"
             - "--leader-election-retry-period=30s"
+            {{- range .Values.csiController.image.csiSnapshotter.additionalArgs }}
+            - {{ . | quote }}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -165,6 +168,9 @@ spec:
             - "--fss-namespace=$(CSI_NAMESPACE)"
             {{- if semverCompare "< 1.24" $.Capabilities.KubeVersion.Version }}
             - "--use-gocsi=false"
+            {{- end }}
+            {{- range .Values.csiController.image.additionalArgs }}
+            - {{ . | quote }}
             {{- end }}
           env:
             - name: CSI_ENDPOINT
@@ -219,7 +225,7 @@ spec:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
             {{- range .Values.csiController.image.livenessProbe.additionalArgs }}
-            - {{ . }}
+            - {{ . | quote }}
             {{- end }}
           {{- with .Values.csiController.image.livenessProbe.resources }}
           resources:
@@ -235,6 +241,9 @@ spec:
             - "--leader-election"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
+            {{- range .Values.csiController.image.vsphereSyncer.additionalArgs }}
+            - {{ . | quote }}
+            {{- end }}
           ports:
             - containerPort: 2113
               name: prometheus
@@ -277,6 +286,9 @@ spec:
             # needed only for topology aware setup
             - "--feature-gates=Topology=true"
             - "--strict-topology"
+            {{- end }}
+            {{- range .Values.csiController.image.csiProvisioner.additionalArgs }}
+            - {{ . | quote }}
             {{- end }}
           env:
             - name: ADDRESS

--- a/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
@@ -73,7 +73,9 @@ spec:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
-            - "--logging-format={{ .Values.csiNode.image.nodeDriverRegistrar.logFormat }}"
+            {{- range .Values.csiNode.image.nodeDriverRegistrar.additionalArgs }}
+            - {{ . }}
+            {{- end }}
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -168,7 +170,9 @@ spec:
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
-            - "--logging-format={{ .Values.csiNode.image.livenessProbe.logFormat }}"
+            {{- range .Values.csiNode.image.livenessProbe.additionalArgs }}
+            - {{ . }}
+            {{- end }}
           {{- with .Values.csiNode.image.livenessProbe.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
@@ -73,7 +73,7 @@ spec:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
-            - "--text=json"
+            - "--logging-format={{ .Values.csiNode.image.nodeDriverRegistrar.logFormat }}"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -94,7 +94,6 @@ spec:
               - /csi-node-driver-registrar
               - --kubelet-registration-path={{ .Values.csiNode.prefixPath }}/var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
               - --mode=kubelet-registration-probe
-              - "--text=json"
             initialDelaySeconds: 3
         - name: vsphere-csi-node
           image: "{{ template "system_default_registry" . }}{{ .Values.csiNode.image.repository }}:{{ .Values.csiNode.image.tag }}"
@@ -105,7 +104,6 @@ spec:
             {{- if semverCompare "< 1.24" $.Capabilities.KubeVersion.Version }}
             - "--use-gocsi=false"
             {{- end }}
-            - "--text=json"
           env:
             - name: NODE_NAME
               valueFrom:
@@ -170,7 +168,7 @@ spec:
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
-            - "--text=json"
+            - "--logging-format={{ .Values.csiNode.image.livenessProbe.logFormat }}"
           {{- with .Values.csiNode.image.livenessProbe.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
@@ -73,6 +73,7 @@ spec:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+            - "--text=json"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -93,6 +94,7 @@ spec:
               - /csi-node-driver-registrar
               - --kubelet-registration-path={{ .Values.csiNode.prefixPath }}/var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
               - --mode=kubelet-registration-probe
+              - "--text=json"
             initialDelaySeconds: 3
         - name: vsphere-csi-node
           image: "{{ template "system_default_registry" . }}{{ .Values.csiNode.image.repository }}:{{ .Values.csiNode.image.tag }}"
@@ -103,6 +105,7 @@ spec:
             {{- if semverCompare "< 1.24" $.Capabilities.KubeVersion.Version }}
             - "--use-gocsi=false"
             {{- end }}
+            - "--text=json"
           env:
             - name: NODE_NAME
               valueFrom:
@@ -167,6 +170,7 @@ spec:
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
+            - "--text=json"
           {{- with .Values.csiNode.image.livenessProbe.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
@@ -74,7 +74,7 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
             {{- range .Values.csiNode.image.nodeDriverRegistrar.additionalArgs }}
-            - {{ . }}
+            - {{ . | quote }}
             {{- end }}
           env:
             - name: ADDRESS
@@ -105,6 +105,9 @@ spec:
             - "--fss-namespace=$(CSI_NAMESPACE)"
             {{- if semverCompare "< 1.24" $.Capabilities.KubeVersion.Version }}
             - "--use-gocsi=false"
+            {{- end }}
+            {{- range .Values.csiNode.image.additionalArgs }}
+            - {{ . | quote }}
             {{- end }}
           env:
             - name: NODE_NAME
@@ -171,7 +174,7 @@ spec:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
             {{- range .Values.csiNode.image.livenessProbe.additionalArgs }}
-            - {{ . }}
+            - {{ . | quote }}
             {{- end }}
           {{- with .Values.csiNode.image.livenessProbe.resources }}
           resources:

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -39,7 +39,7 @@ csiController:
       repository: rancher/mirrored-sig-storage-csi-attacher
       tag: latest
       imagePullPolicy: ""
-      logFormat: text
+      additionalArgs: []
       resources: {}
       #resources:
       # limits:
@@ -52,7 +52,7 @@ csiController:
       repository: rancher/mirrored-sig-storage-csi-resizer
       tag: latest
       imagePullPolicy: ""
-      logFormat: text
+      additionalArgs: []
       resources: {}
       #resources:
       # limits:
@@ -65,7 +65,7 @@ csiController:
       repository: rancher/mirrored-sig-storage-livenessprobe
       tag: latest
       imagePullPolicy: ""
-      logFormat: text
+      additionalArgs: []
       resources: {}
       #resources:
       # limits:
@@ -193,7 +193,7 @@ csiNode:
       repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
       tag: latest
       imagePullPolicy: ""
-      logFormat: "text"
+      additionalArgs: []
       resources: {}
       #resources:
       # limits:
@@ -206,7 +206,7 @@ csiNode:
       repository: rancher/mirrored-sig-storage-livenessprobe
       tag: latest
       imagePullPolicy: ""
-      logFormat: "text"
+      additionalArgs: []
       resources: {}
       #resources:
       # limits:

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -27,7 +27,6 @@ csiController:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
     tag: latest
     imagePullPolicy: ""
-    logFormat: text
     resources: {}
     #resources:
     # limits:
@@ -79,7 +78,6 @@ csiController:
       repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
       tag: latest
       imagePullPolicy: ""
-      logFormat: text
       resources: {}
       #resources:
       # limits:
@@ -92,7 +90,6 @@ csiController:
       repository: rancher/mirrored-sig-storage-csi-provisioner
       tag: latest
       imagePullPolicy: ""
-      logFormat: text
       resources: {}
       #resources:
       # limits:
@@ -105,7 +102,6 @@ csiController:
       repository: rancher/mirrored-sig-storage-csi-snapshotter
       tag: latest
       imagePullPolicy: ""
-      logFormat: text
       resources: {}
       #resources:
       # limits:
@@ -185,7 +181,6 @@ csiNode:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
     tag: latest
     imagePullPolicy: ""
-    logFormat: text
     resources: {}
     #resources:
     # limits:
@@ -198,7 +193,7 @@ csiNode:
       repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
       tag: latest
       imagePullPolicy: ""
-      logFormat: text
+      logFormat: "text"
       resources: {}
       #resources:
       # limits:
@@ -211,7 +206,7 @@ csiNode:
       repository: rancher/mirrored-sig-storage-livenessprobe
       tag: latest
       imagePullPolicy: ""
-      logFormat: text
+      logFormat: "text"
       resources: {}
       #resources:
       # limits:

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -27,6 +27,7 @@ csiController:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
     tag: latest
     imagePullPolicy: ""
+    logFormat: text
     resources: {}
     #resources:
     # limits:
@@ -39,6 +40,7 @@ csiController:
       repository: rancher/mirrored-sig-storage-csi-attacher
       tag: latest
       imagePullPolicy: ""
+      logFormat: text
       resources: {}
       #resources:
       # limits:
@@ -51,6 +53,7 @@ csiController:
       repository: rancher/mirrored-sig-storage-csi-resizer
       tag: latest
       imagePullPolicy: ""
+      logFormat: text
       resources: {}
       #resources:
       # limits:
@@ -63,6 +66,7 @@ csiController:
       repository: rancher/mirrored-sig-storage-livenessprobe
       tag: latest
       imagePullPolicy: ""
+      logFormat: text
       resources: {}
       #resources:
       # limits:
@@ -75,6 +79,7 @@ csiController:
       repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
       tag: latest
       imagePullPolicy: ""
+      logFormat: text
       resources: {}
       #resources:
       # limits:
@@ -87,6 +92,7 @@ csiController:
       repository: rancher/mirrored-sig-storage-csi-provisioner
       tag: latest
       imagePullPolicy: ""
+      logFormat: text
       resources: {}
       #resources:
       # limits:
@@ -99,6 +105,7 @@ csiController:
       repository: rancher/mirrored-sig-storage-csi-snapshotter
       tag: latest
       imagePullPolicy: ""
+      logFormat: text
       resources: {}
       #resources:
       # limits:
@@ -178,6 +185,7 @@ csiNode:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
     tag: latest
     imagePullPolicy: ""
+    logFormat: text
     resources: {}
     #resources:
     # limits:
@@ -190,6 +198,7 @@ csiNode:
       repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
       tag: latest
       imagePullPolicy: ""
+      logFormat: text
       resources: {}
       #resources:
       # limits:
@@ -202,6 +211,7 @@ csiNode:
       repository: rancher/mirrored-sig-storage-livenessprobe
       tag: latest
       imagePullPolicy: ""
+      logFormat: text
       resources: {}
       #resources:
       # limits:

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -27,6 +27,7 @@ csiController:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
     tag: latest
     imagePullPolicy: ""
+    additionalArgs: []
     resources: {}
     #resources:
     # limits:
@@ -78,6 +79,7 @@ csiController:
       repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
       tag: latest
       imagePullPolicy: ""
+      additionalArgs: []
       resources: {}
       #resources:
       # limits:
@@ -90,6 +92,7 @@ csiController:
       repository: rancher/mirrored-sig-storage-csi-provisioner
       tag: latest
       imagePullPolicy: ""
+      additionalArgs: []
       resources: {}
       #resources:
       # limits:
@@ -102,6 +105,7 @@ csiController:
       repository: rancher/mirrored-sig-storage-csi-snapshotter
       tag: latest
       imagePullPolicy: ""
+      additionalArgs: []
       resources: {}
       #resources:
       # limits:
@@ -181,6 +185,7 @@ csiNode:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
     tag: latest
     imagePullPolicy: ""
+    additionalArgs: []
     resources: {}
     #resources:
     # limits:


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] Chart version has been incremented (if necessary)
- [ ] That helm lint and pack run successfully on the chart.
- [ ] Deployment of the chart has been tested and verified that it functions as expected.
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Feature - adds support for additional args (which covers specifying logging format) of CSI containers

#### Linked Issues ####

tries to fix https://github.com/rancher/vsphere-charts/issues/95

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.