### PR TITLE
Customize MAX_VOLUMES_PER_NODE, allowing for more than 59 disks per VM

### DIFF
--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
   catalog.cattle.io/rancher-version: '>= 2.9.0-0'
   catalog.cattle.io/release-name: vsphere-csi
 apiVersion: v1
-appVersion: 3.3.1-rancher7
+appVersion: 3.3.1-rancher8
 description: vSphere Cloud Storage Interface (CSI)
 icon: https://charts.rancher.io/assets/logos/vsphere-csi.svg
 keywords:
@@ -21,4 +21,4 @@ maintainers:
 name: rancher-vsphere-csi
 sources:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.3.1-rancher7
+version: 3.3.1-rancher8

--- a/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
@@ -117,8 +117,8 @@ spec:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
             - name: MAX_VOLUMES_PER_NODE
-              {{- if .Values.maxPvscsiTargetsPerVm.enabled }}
-              {{-   if gt .Values.csiNode.maxVolumesPerNode 255 }}
+              {{- if and (.Values.maxPvscsiTargetsPerVm.enabled) (gt (int .Values.csiNode.maxVolumesPerNode) 0 ) }}
+              {{-   if gt (int .Values.csiNode.maxVolumesPerNode) 255 }}
               value: "255"
               {{-   else }}
               value: "{{ .Values.csiNode.maxVolumesPerNode }}"

--- a/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
@@ -117,7 +117,15 @@ spec:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
             - name: MAX_VOLUMES_PER_NODE
-              value: "59" # Maximum number of volumes that controller can publish to the node. If value is not set or zero Kubernetes decide how many volumes can be published by the controller to the node.
+              {{- if .Values.maxPvscsiTargetsPerVm.enabled }}
+              {{-   if gt .Values.csiNode.maxVolumesPerNode 255 }}
+              value: "255"
+              {{-   else }}
+              value: "{{ .Values.csiNode.maxVolumesPerNode }}"
+              {{-   end }}
+              {{- else }}
+              value: "59"
+              {{- end }} 
             - name: X_CSI_MODE
               value: "node"
             - name: X_CSI_SPEC_REQ_VALIDATION

--- a/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
@@ -119,10 +119,9 @@ spec:
             # Maximum number of volumes that controller can publish to the node. 
             # If value is not set or zero Kubernetes decide how many volumes can be published by the controller to the node.
             - name: MAX_VOLUMES_PER_NODE
-            # To be able to attach more than 59 CNS disks per VM, it is necessary to set the feature gate pvscsiCtrlr256DiskSupportEnabled 
-            # to true in the vCenter server appliance (/usr/lib/vmware-vsan/VsanVcMgmtConfig.xml or /usr/lib/vmware-vpx/vsan-health/VsanVcMgmtConfig.xml),
-            # depending on your vCenter version. Do not forget to restart vsan-health service: service-control --restart vmware-vsan-health
-            # This feature seems to be available from vSphere 7 update 3. Your VM also need a Virtual Hardware Version that allows for 64 disks per PvSCSI controller.
+            # Attaching more than 59 CNS disks per VM is possible since vSphere 8. To use it, set the feature gate pvscsiCtrlr256DiskSupportEnabled to true
+            # in the vCenter server appliance (/usr/lib/vmware-vsan/VsanVcMgmtConfig.xml). Do not forget to restart vsan-health service: service-control --restart vmware-vsan-health
+            # Your VM also need a Virtual Hardware Version that allows for 64 disks per PvSCSI controller.
               {{- if and (.Values.maxPvscsiTargetsPerVm.enabled) (gt (int .Values.csiNode.maxVolumesPerNode) 0 ) }}
               {{-   if gt (int .Values.csiNode.maxVolumesPerNode) 255 }}
               value: "255"

--- a/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
@@ -115,8 +115,14 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
-              value: unix:///csi/csi.sock
+              value: unix:///csi/csi.sock]
+            # Maximum number of volumes that controller can publish to the node. 
+            # If value is not set or zero Kubernetes decide how many volumes can be published by the controller to the node.
             - name: MAX_VOLUMES_PER_NODE
+            # To be able to attach more than 59 CNS disks per VM, it is necessary to set the feature gate pvscsiCtrlr256DiskSupportEnabled 
+            # to true in the vCenter server appliance (/usr/lib/vmware-vsan/VsanVcMgmtConfig.xml or /usr/lib/vmware-vpx/vsan-health/VsanVcMgmtConfig.xml),
+            # depending on your vCenter version. Do not forget to restart vsan-health service: service-control --restart vmware-vsan-health
+            # This feature seems to be available from vSphere 7 update 3. Your VM also need a Virtual Hardware Version that allows for 64 disks per PvSCSI controller.
               {{- if and (.Values.maxPvscsiTargetsPerVm.enabled) (gt (int .Values.csiNode.maxVolumesPerNode) 0 ) }}
               {{-   if gt (int .Values.csiNode.maxVolumesPerNode) 255 }}
               value: "255"

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -181,6 +181,9 @@ csiNode:
   podLabels: {}
   prefixPath: ""
   prefixPathWindows: ""
+  # Maximum number of volumes that controller can publish to the node. 
+  # If value is not set or zero Kubernetes decide how many volumes can be published by the controller to the node.
+  maxVolumesPerNode: "59" 
   image:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
     tag: latest


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [X] Chart version has been incremented (if necessary)
- [X] That helm lint and pack run successfully on the chart.
- [X] Deployment of the chart has been tested and verified that it functions as expected.
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

In order to allow the use of more than 59 CNS volumes in a node, it is both necessary to:

* Set the feature flag `maxPvscsiTargetsPerVM.enabled` to `true`
* Set node agent environment variable `MAX_VOLUMES_PER_NODE` to be greater than `59` (up to `255` supported)

The latter required manual intervention in vsphere-csi-node DaemonSet. With this pull request it is possible to set the `csiNode.maxVolumesPerNode` parameter to the desired value, up to `255` (maximum supported by vSphere currently) if, and only if, `maxPvscsiTargetsPerVM.enabled` is set to `true`.

#### Linked Issues ####

(https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/2800)

#### Additional Notes ####

Please note that it is also necessary to adjust a vCenter config file (as per the linked issue above):
* Log in to vCenter using SSH
* Edit the file `/usr/lib/vmware-vsan/VsanVcMgmtConfig.xml` and set the parameter `pvscsiCtrlr256DiskSupportEnabled` to `true`
* Restart `vsan-health` using the command `service-control --restart vmware-vsan-health`

The procedure was tested using vSphere 8 update 3. After restarting `vsan-health` service and setting the correct parameters in vSphere CSI Driver, it was possible to attach more than 59 CNS disks in a single VM.
