### PR TITLE
feat(imagePullSecrets): Add option for imagePullSecrets to 'deploymen…

### DIFF
--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -21,4 +21,4 @@ maintainers:
 name: rancher-vsphere-csi
 sources:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.3.1-rancher8
+version: 3.3.1-rancher9

--- a/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
+++ b/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
@@ -81,6 +81,10 @@ spec:
           effect: NoExecute
           operator: Exists
       {{- end }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       dnsPolicy: "Default"
       containers:
         - name: csi-attacher

--- a/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
@@ -63,6 +63,10 @@ spec:
           operator: Exists
       {{- end }}
       serviceAccountName: vsphere-csi-node
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       hostNetwork: true
       dnsPolicy: "ClusterFirstWithHostNet"
       containers:

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -234,6 +234,7 @@ storageClass:
   reclaimPolicy: Delete
 
 global:
+  imagePullSecrets: []
   cattle:
     systemDefaultRegistry: ""
 


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] Chart version has been incremented (if necessary)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Add option for pulling images from Private Registries.

`imagePullSecrets` was added to `daemonset` and `deployment`.

Option was added to values.yaml in `.global.imagePullSecrets` section.

Chart version bumped to `3.3.1-rancher9`
#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.