### PR TITLE
Fix type on csi.sock

### DIFF
--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
   catalog.cattle.io/rancher-version: '>= 2.9.0-0'
   catalog.cattle.io/release-name: vsphere-csi
 apiVersion: v1
-appVersion: 3.3.1-rancher8
+appVersion: 3.3.1-rancher9
 description: vSphere Cloud Storage Interface (CSI)
 icon: https://charts.rancher.io/assets/logos/vsphere-csi.svg
 keywords:
@@ -21,4 +21,4 @@ maintainers:
 name: rancher-vsphere-csi
 sources:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.3.1-rancher8
+version: 3.3.1-rancher9

--- a/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
+++ b/charts/rancher-vsphere-csi/templates/node/daemonset.yaml
@@ -115,7 +115,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: CSI_ENDPOINT
-              value: unix:///csi/csi.sock]
+              value: unix:///csi/csi.sock
             # Maximum number of volumes that controller can publish to the node. 
             # If value is not set or zero Kubernetes decide how many volumes can be published by the controller to the node.
             - name: MAX_VOLUMES_PER_NODE


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [ ] Chart version has been incremented (if necessary)
- [ ] That helm lint and pack run successfully on the chart.
- [ ] Deployment of the chart has been tested and verified that it functions as expected.
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####
Typo fix 
<!-- New image, version bump. script update, etc etc -->

#### Linked Issues ####
https://github.com/rancher/vsphere-charts/issues/100
<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.