### PR TITLE
Update prerequisites to require vCenter 7.0+ for CSI driver compatibility

### DIFF
--- a/charts/rancher-vsphere-csi/README.md
+++ b/charts/rancher-vsphere-csi/README.md
@@ -8,7 +8,8 @@ The CSI driver for vSphere is `csi.vsphere.vmware.com`.
 
 ## Prerequisites
 
-- vSphere 6.7 U3+
+- vCenter 7.0+
+- vSphere 6.7 U3+ (ESXi hosts)
 - Kubernetes v1.20+
 - Out-of-tree vSphere Cloud Provider Interface (CPI)
 - A Secret on your Kubernetes cluster that contains vSphere CSI configuration and credentials

--- a/charts/rancher-vsphere-csi/app-readme.md
+++ b/charts/rancher-vsphere-csi/app-readme.md
@@ -8,7 +8,8 @@ The CSI driver for vSphere is `csi.vsphere.vmware.com`.
 
 ## Prerequisites
 
-- vSphere 6.7 U3+
+- vCenter 7.0+
+- vSphere 6.7 U3+ (ESXi hosts)
 - Kubernetes v1.14+
 - Out-of-tree vSphere Cloud Provider Interface (CPI)
 - A Secret on your Kubernetes cluster that contains vSphere CSI configuration and credentials (Refer to `README` or `Detailed Descriptions`)


### PR DESCRIPTION
## Description
This PR updates the prerequisites in app-readme.md and README.md to specify that vCenter 7.0+ is required for the CSI driver to function properly. This change reflects the incompatibility described in kubernetes-sigs/vsphere-csi-driver#3000, where the latest CSI driver does not work with vCenter 6.7u3.

ESXi hosts can still be at vSphere 6.7+, only the vCenter requirement has been updated.

## Related Issue
Fixes #102

## Type of change
- [x] Documentation update

## Testing
Documentation change only, no functional testing required.