### PR TITLE
Add configEnabled values to toggle CM creation

### DIFF
--- a/charts/rancher-vsphere-cpi/Chart.yaml
+++ b/charts/rancher-vsphere-cpi/Chart.yaml
@@ -21,4 +21,4 @@ maintainers:
 name: rancher-vsphere-cpi
 sources:
 - https://github.com/kubernetes/cloud-provider-vsphere
-version: 1.10.1
+version: 1.10.2

--- a/charts/rancher-vsphere-cpi/templates/configmap.yaml
+++ b/charts/rancher-vsphere-cpi/templates/configmap.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.vCenter.cloudConfig.generate }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: vsphere-cloud-config
+  name: {{ .Values.vCenter.cloudConfig.name | default "vsphere-cloud-config" | quote }}
   labels:
     vsphere-cpi-infra: config
     component: {{ .Chart.Name }}-cloud-controller-manager
@@ -40,3 +41,4 @@ data:
     {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- end }}
+{{- end }}

--- a/charts/rancher-vsphere-cpi/templates/daemonset.yaml
+++ b/charts/rancher-vsphere-cpi/templates/daemonset.yaml
@@ -116,4 +116,4 @@ spec:
       volumes:
       - name: vsphere-config-volume
         configMap:
-          name: vsphere-cloud-config
+          name: {{ .Values.vCenter.cloudConfig.name | default "vsphere-cloud-config" | quote }}

--- a/charts/rancher-vsphere-cpi/values.yaml
+++ b/charts/rancher-vsphere-cpi/values.yaml
@@ -8,7 +8,9 @@ vCenter:
   credentialsSecret:
     name: "vsphere-cpi-creds"
     generate: true
-
+  cloudConfig:
+    name: "vsphere-cloud-config"
+    generate: true
   # vSphere Tags used to determine the zone and region of a Kubernetes node. This labels will be propagated to NodeLabels
   labels:
     region: "k8s-region"


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [ ] Chart version has been incremented (if necessary)
- [ ] That helm lint and pack run successfully on the chart.
- [ ] Deployment of the chart has been tested and verified that it functions as expected.
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####

Add configEnabled values to toggle CM creation, this allows users to pass their own. The change is similar to upstream chart feature https://github.com/kubernetes/cloud-provider-vsphere/blob/master/charts/vsphere-cpi/templates/configmap.yaml#L7

<!-- New image, version bump. script update, etc etc -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.