### PR TITLE
Fix vsphere cpi dns policy

### DIFF
--- a/charts/rancher-vsphere-cpi/Chart.yaml
+++ b/charts/rancher-vsphere-cpi/Chart.yaml
@@ -21,4 +21,4 @@ maintainers:
 name: rancher-vsphere-cpi
 sources:
 - https://github.com/kubernetes/cloud-provider-vsphere
-version: 1.12.0
+version: 1.12.1

--- a/charts/rancher-vsphere-cpi/templates/daemonset.yaml
+++ b/charts/rancher-vsphere-cpi/templates/daemonset.yaml
@@ -113,7 +113,7 @@ spec:
           {{- end }}
           {{- end }}
       hostNetwork: true
-      dnsPolicy: {{ .Values.cloudControllerManager.dnsPolicy | default "ClusterFirstWithHostNet" }}
+      dnsPolicy: {{ .Values.cloudControllerManager.dnsPolicy | default "Default" }}
       volumes:
       - name: vsphere-config-volume
         configMap:

--- a/charts/rancher-vsphere-cpi/values.yaml
+++ b/charts/rancher-vsphere-cpi/values.yaml
@@ -98,7 +98,10 @@ cloudControllerManager:
   env: []
   # Pod DNS policy
   # Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
-  dnsPolicy: "ClusterFirstWithHostNet"
+  # Note that CPI pods run with host network and need to communicate with the
+  # vsphere server in order to clear the uninitialized taint from nodes before
+  # CoreDNS can start, so this pod SHOULD NOT rely on cluster DNS.
+  dnsPolicy: "Default"
 
 global:
   cattle:


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Chart version has been incremented (if necessary)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.

#### Types of Change ####

bugfix for regression introduced in https://github.com/rancher/vsphere-charts/pull/114

#### Linked Issues ####

* https://github.com/rancher/rke2/issues/8934

#### Additional Notes ####

