### PR TITLE
Bump for Kubernetes 1.36

### DIFF
--- a/charts/rancher-vsphere-cpi/Chart.yaml
+++ b/charts/rancher-vsphere-cpi/Chart.yaml
@@ -21,4 +21,4 @@ maintainers:
 name: rancher-vsphere-cpi
 sources:
 - https://github.com/kubernetes/cloud-provider-vsphere
-version: 1.13.1
+version: 1.14.0

--- a/charts/rancher-vsphere-cpi/Chart.yaml
+++ b/charts/rancher-vsphere-cpi/Chart.yaml
@@ -1,14 +1,14 @@
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/display-name: vSphere CPI
-  catalog.cattle.io/kube-version: '>= 1.27.0-0 < 1.36.0-0'
+  catalog.cattle.io/kube-version: '>= 1.27.0-0 < 1.37.0-0'
   catalog.cattle.io/namespace: kube-system
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux,windows
   catalog.cattle.io/rancher-version: '>= 2.9.0-0'
   catalog.cattle.io/release-name: vsphere-cpi
 apiVersion: v1
-appVersion: 1.35.0
+appVersion: 1.36.0
 description: vSphere Cloud Provider Interface (CPI)
 icon: https://charts.rancher.io/assets/logos/vsphere-cpi.svg
 keywords:
@@ -21,4 +21,4 @@ maintainers:
 name: rancher-vsphere-cpi
 sources:
 - https://github.com/kubernetes/cloud-provider-vsphere
-version: 1.13.0
+version: 1.13.1

--- a/charts/rancher-vsphere-cpi/values.yaml
+++ b/charts/rancher-vsphere-cpi/values.yaml
@@ -45,6 +45,11 @@ nodes:
 # Supported versions can be found at:
 # https://github.com/kubernetes/cloud-provider-vsphere#compatibility-with-kubernetes
 versionOverrides:
+  - constraint: "~ 1.36"
+    values:
+      cloudControllerManager:
+        repository: rancher/mirrored-cloud-provider-vsphere
+        tag: v1.36.0
   - constraint: "~ 1.35"
     values:
       cloudControllerManager:

--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -21,4 +21,4 @@ maintainers:
 name: rancher-vsphere-csi
 sources:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.6.0-rancher2
+version: 3.7.0-rancher1

--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/display-name: vSphere CSI
-  catalog.cattle.io/kube-version: '>= 1.27.0-0 < 1.36.0-0'
+  catalog.cattle.io/kube-version: '>= 1.27.0-0 < 1.37.0-0'
   catalog.cattle.io/namespace: kube-system
   catalog.cattle.io/os: linux,windows
   catalog.cattle.io/permits-os: linux,windows
@@ -21,4 +21,4 @@ maintainers:
 name: rancher-vsphere-csi
 sources:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.6.0-rancher1
+version: 3.6.0-rancher2

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -294,7 +294,7 @@ global:
 # https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/3.0/vmware-vsphere-csp-getting-started/GUID-D4AAD99E-9128-40CE-B89C-AD451DA8379D.html#kubernetes-versions-compatible-with-vsphere-container-storage-plugin-1
 versionOverrides:
   # Versions from https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/v3.6.0/manifests/vanilla/vsphere-csi-driver.yaml
-  - constraint: ">= 1.31 < 1.36"
+  - constraint: ">= 1.31 < 1.37"
     values:
       csiController:
         image:

--- a/tests/unit/cpi_template_test.go
+++ b/tests/unit/cpi_template_test.go
@@ -29,6 +29,17 @@ func TestCPITemplateRenderedDaemonset(t *testing.T) {
 		args args
 	}{
 		{
+			name: "Kubernetes 1.36",
+			args: args{
+				values:        map[string]string{},
+				kubeVersion:   "1.36",
+				namespace:     "cpitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:   "cpitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:  cpiChart,
+				expectedImage: "rancher/mirrored-cloud-provider-vsphere:v1.36.0",
+			},
+		},
+		{
 			name: "Kubernetes 1.35",
 			args: args{
 				values:        map[string]string{},

--- a/tests/unit/csi_template_test.go
+++ b/tests/unit/csi_template_test.go
@@ -29,6 +29,40 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 		args args
 	}{
 		{
+			name: "Kubernetes 1.36 Linux Only",
+			args: args{
+				values:         map[string]string{"vCenter.clusterId": random.UniqueId()},
+				kubeVersion:    "1.36",
+				namespace:      "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:    "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath:   csiChart,
+				windowsEnabled: false,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.13.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.6.0",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.15.0",
+				},
+			},
+		},
+		{
+			name: "Kubernetes 1.36 Linux and Windows",
+			args: args{
+				values: map[string]string{
+					"vCenter.clusterId":         random.UniqueId(),
+					"csiWindowsSupport:enabled": "true",
+				},
+				kubeVersion:  "1.36",
+				namespace:    "csitest-" + strings.ToLower(random.UniqueId()),
+				releaseName:  "csitest-" + strings.ToLower(random.UniqueId()),
+				chartRelPath: csiChart,
+				expectedImages: []string{
+					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.13.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.6.0",
+					"rancher/mirrored-sig-storage-livenessprobe:v2.15.0",
+				},
+			},
+		},
+		{
 			name: "Kubernetes 1.35 Linux Only",
 			args: args{
 				values:         map[string]string{"vCenter.clusterId": random.UniqueId()},


### PR DESCRIPTION
#### Pull Request Checklist ####

- [x] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/artifact-mirror)
- [x] Chart version has been incremented (if necessary)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.

#### Types of Change ####

version bump

#### Linked Issues ####


#### Additional Notes ####


#### After the PR is merged ####