### PR TITLE
Bump csi to 3.7.2

### DIFF
--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
   catalog.cattle.io/rancher-version: '>= 2.9.0-0'
   catalog.cattle.io/release-name: vsphere-csi
 apiVersion: v1
-appVersion: 3.6.0
+appVersion: 3.7.2
 description: vSphere Cloud Storage Interface (CSI)
 icon: https://charts.rancher.io/assets/logos/vsphere-csi.svg
 keywords:
@@ -21,4 +21,4 @@ maintainers:
 name: rancher-vsphere-csi
 sources:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.7.0-rancher1
+version: 3.7.2-rancher1

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -293,13 +293,13 @@ global:
 # Supported versions can be found at:
 # https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/3.0/vmware-vsphere-csp-getting-started/GUID-D4AAD99E-9128-40CE-B89C-AD451DA8379D.html#kubernetes-versions-compatible-with-vsphere-container-storage-plugin-1
 versionOverrides:
-  # Versions from https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/v3.6.0/manifests/vanilla/vsphere-csi-driver.yaml
+  # Versions from https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/v3.7.2/manifests/vanilla/vsphere-csi-driver.yaml
   - constraint: ">= 1.31 < 1.37"
     values:
       csiController:
         image:
           repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
-          tag: v3.6.0
+          tag: v3.7.2
           csiAttacher:
             repository: rancher/mirrored-sig-storage-csi-attacher
             tag: v4.9.0
@@ -311,7 +311,7 @@ versionOverrides:
             tag: v2.15.0
           vsphereSyncer:
             repository: rancher/mirrored-cloud-provider-vsphere-csi-release-syncer
-            tag: v3.6.0
+            tag: v3.7.2
           csiProvisioner:
             repository: rancher/mirrored-sig-storage-csi-provisioner
             tag: v4.0.1
@@ -321,7 +321,7 @@ versionOverrides:
       csiNode:
         image:
           repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
-          tag: v3.6.0
+          tag: v3.7.2
           nodeDriverRegistrar:
             repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
             tag: v2.13.0

--- a/tests/unit/csi_template_test.go
+++ b/tests/unit/csi_template_test.go
@@ -39,7 +39,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				windowsEnabled: false,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.13.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.7.2",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.15.0",
 				},
 			},
@@ -57,7 +57,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				chartRelPath: csiChart,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.13.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.7.2",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.15.0",
 				},
 			},
@@ -73,7 +73,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				windowsEnabled: false,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.13.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.7.2",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.15.0",
 				},
 			},
@@ -91,7 +91,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				chartRelPath: csiChart,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.13.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.7.2",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.15.0",
 				},
 			},
@@ -107,7 +107,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				windowsEnabled: false,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.13.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.7.2",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.15.0",
 				},
 			},
@@ -125,7 +125,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				chartRelPath: csiChart,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.13.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.7.2",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.15.0",
 				},
 			},
@@ -141,7 +141,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				windowsEnabled: false,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.13.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.7.2",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.15.0",
 				},
 			},
@@ -159,7 +159,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				chartRelPath: csiChart,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.13.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.7.2",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.15.0",
 				},
 			},
@@ -175,7 +175,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				windowsEnabled: false,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.13.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.7.2",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.15.0",
 				},
 			},
@@ -193,7 +193,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				chartRelPath: csiChart,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.13.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.7.2",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.15.0",
 				},
 			},
@@ -209,7 +209,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				windowsEnabled: false,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.13.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.7.2",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.15.0",
 				},
 			},
@@ -227,7 +227,7 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				chartRelPath: csiChart,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-node-driver-registrar:v2.13.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.7.2",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.15.0",
 				},
 			},
@@ -438,9 +438,9 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				csiResizerEnabled: false,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-attacher:v4.9.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.7.2",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.15.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.7.2",
 					"rancher/mirrored-sig-storage-csi-provisioner:v4.0.1",
 				},
 			},
@@ -456,9 +456,9 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				csiResizerEnabled: false,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-attacher:v4.9.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.7.2",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.15.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.7.2",
 					"rancher/mirrored-sig-storage-csi-provisioner:v4.0.1",
 				},
 			},
@@ -474,9 +474,9 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				csiResizerEnabled: false,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-attacher:v4.9.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.7.2",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.15.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.7.2",
 					"rancher/mirrored-sig-storage-csi-provisioner:v4.0.1",
 				},
 			},
@@ -492,9 +492,9 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				csiResizerEnabled: false,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-attacher:v4.9.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.7.2",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.15.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.7.2",
 					"rancher/mirrored-sig-storage-csi-provisioner:v4.0.1",
 				},
 			},
@@ -510,9 +510,9 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				csiResizerEnabled: false,
 				expectedImages: []string{
 					"rancher/mirrored-sig-storage-csi-attacher:v4.9.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-driver:v3.7.2",
 					"rancher/mirrored-sig-storage-livenessprobe:v2.15.0",
-					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.6.0",
+					"rancher/mirrored-cloud-provider-vsphere-csi-release-syncer:v3.7.2",
 					"rancher/mirrored-sig-storage-csi-provisioner:v4.0.1",
 				},
 			},


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

#### Pull Request Checklist ####

- [x] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] Chart version has been incremented (if necessary)
- [x] That helm lint and pack run successfully on the chart.
- [ ] Deployment of the chart has been tested and verified that it functions as expected.
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####
Bump to 3.7.2 release 
<!-- New image, version bump. script update, etc etc -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.