### PR TITLE
Watch the github repo, not the image repo for the hardened CPI bumps

### DIFF
--- a/updatecli/updatecli.d/update-cpi-image.yaml
+++ b/updatecli/updatecli.d/update-cpi-image.yaml
@@ -2,14 +2,20 @@ name: "Update Rancher vSphere CPI prime tags"
 
 sources:
   cpiPrime:
-    name: Get latest hardened vSphere CPI tag
-    kind: dockerimage
+    name: Get latest vSphere CPI release tag
+    kind: githubrelease
     spec:
-      image: '{{ .images.primeRegistryRepo }}/hardened-cloud-provider-vsphere'
-      tagfilter: '^v[0-9]+\.[0-9]+\.[0-9]+-build[0-9]+$'
+      owner: rancher
+      repository: image-build-cloud-provider-vsphere
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
+      typefilter:
+        release: true
+        draft: false
+        prerelease: false
       versionfilter:
-        kind: semver
-        pattern: ">=0.0.0"
+        kind: regex
+        pattern: '^v[0-9]+\.[0-9]+\.[0-9]+-build[0-9]+$'
 
 targets:
   cpiPrimeTag:

--- a/updatecli/updatecli.d/update-csi-imges.yaml
+++ b/updatecli/updatecli.d/update-csi-imges.yaml
@@ -9,7 +9,7 @@ sources:
       tagfilter: '^v[0-9]+\.[0-9]+\.[0-9]+-build[0-9]+$'
       versionfilter:
         kind: semver
-        pattern: ">=0.0.0"
+        pattern: ">=0.0.0-0"
 
   csiAttacherPrime:
     name: Get latest hardened CSI attacher tag
@@ -19,7 +19,7 @@ sources:
       tagfilter: '^v[0-9]+\.[0-9]+\.[0-9]+-build[0-9]+$'
       versionfilter:
         kind: semver
-        pattern: ">=0.0.0"
+        pattern: ">=0.0.0-0"
 
   csiResizerPrime:
     name: Get latest hardened CSI resizer tag
@@ -29,7 +29,7 @@ sources:
       tagfilter: '^v[0-9]+\.[0-9]+\.[0-9]+-build[0-9]+$'
       versionfilter:
         kind: semver
-        pattern: ">=0.0.0"
+        pattern: ">=0.0.0-0"
 
   livenessProbePrime:
     name: Get latest hardened livenessprobe tag
@@ -39,7 +39,7 @@ sources:
       tagfilter: '^v[0-9]+\.[0-9]+\.[0-9]+-build[0-9]+$'
       versionfilter:
         kind: semver
-        pattern: ">=0.0.0"
+        pattern: ">=0.0.0-0"
 
   vsphereSyncerPrime:
     name: Get latest hardened vSphere CSI syncer tag
@@ -49,7 +49,7 @@ sources:
       tagfilter: '^v[0-9]+\.[0-9]+\.[0-9]+-build[0-9]+$'
       versionfilter:
         kind: semver
-        pattern: ">=0.0.0"
+        pattern: ">=0.0.0-0"
 
   csiProvisionerPrime:
     name: Get latest hardened CSI provisioner tag
@@ -59,7 +59,7 @@ sources:
       tagfilter: '^v[0-9]+\.[0-9]+\.[0-9]+-build[0-9]+$'
       versionfilter:
         kind: semver
-        pattern: ">=0.0.0"
+        pattern: ">=0.0.0-0"
 
   csiSnapshotterPrime:
     name: Get latest hardened CSI snapshotter tag
@@ -69,7 +69,7 @@ sources:
       tagfilter: '^v[0-9]+\.[0-9]+\.[0-9]+-build[0-9]+$'
       versionfilter:
         kind: semver
-        pattern: ">=0.0.0"
+        pattern: ">=0.0.0-0"
 
   nodeDriverRegistrarPrime:
     name: Get latest hardened CSI node-driver-registrar tag
@@ -79,7 +79,7 @@ sources:
       tagfilter: '^v[0-9]+\.[0-9]+\.[0-9]+-build[0-9]+$'
       versionfilter:
         kind: semver
-        pattern: ">=0.0.0"
+        pattern: ">=0.0.0-0"
 
 targets:
   csiDriverPrimeTag:


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [ ] Chart version has been incremented (if necessary)
- [ ] That helm lint and pack run successfully on the chart.
- [ ] Deployment of the chart has been tested and verified that it functions as expected.
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####
- This changes to watching the [rancher/image-build-cloud-provider-vsphere](https://github.com/rancher/image-build-cloud-provider-vsphere) github releases instead of the prime registry. Aligns with how we watch in `rke2-charts` for other image bumps.
<!-- New image, version bump. script update, etc etc -->
- Expand the version allowance on CSI to allow the `-buildXXXX` suffix release to be considered valid. 
#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.