### PR TITLE
Deploy minor specific hardened CPI images

### DIFF
--- a/.github/workflows/updatecli-csi-prime-tags.yml
+++ b/.github/workflows/updatecli-csi-prime-tags.yml
@@ -21,7 +21,7 @@ jobs:
         uses: updatecli/updatecli-action@5bda7da77bf4d181bce5f807d73d832b62062acf # v3.3.0
 
       - name: Apply Updatecli (CSI and CPI)
-        run: updatecli apply --clean --config ./updatecli/updatecli.d/update-csi-cpi-images.yaml --values ./updatecli/values.yaml
+        run: updatecli apply --clean --config ./updatecli/updatecli.d/ --values ./updatecli/values.yaml
         env:
           UPDATECLI_GITHUB_ACTOR: ${{ github.actor }}
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/charts/rancher-vsphere-cpi/values.yaml
+++ b/charts/rancher-vsphere-cpi/values.yaml
@@ -50,21 +50,25 @@ versionOverrides:
       cloudControllerManager:
         repository: rancher/mirrored-cloud-provider-vsphere
         tag: v1.36.0
+        primeTag: v1.36.0-build20260710
   - constraint: "~ 1.35"
     values:
       cloudControllerManager:
         repository: rancher/mirrored-cloud-provider-vsphere
-        tag: v1.35.0
+        tag: v1.35.1
+        primeTag: v1.35.1-build20260710
   - constraint: "~ 1.34"
     values:
       cloudControllerManager:
         repository: rancher/mirrored-cloud-provider-vsphere
         tag: v1.34.0
+        primeTag: v1.34.0-build20260710
   - constraint: "~ 1.33"
     values:
       cloudControllerManager:
         repository: rancher/mirrored-cloud-provider-vsphere
-        tag: v1.33.0
+        tag: v1.33.1
+        primeTag: v1.33.1-build20260710
   - constraint: "~ 1.32"
     values:
       cloudControllerManager:
@@ -100,7 +104,7 @@ cloudControllerManager:
   repository: rancher/mirrored-cloud-provider-vsphere-cpi-release-manager
   primeRepository: rancher/hardened-cloud-provider-vsphere
   tag: latest
-  primeTag: v1.36.0-build20260710
+  primeTag: latest
   nodeSelector: {}
   tolerations: []
   ## Optional additional labels to add to pods

--- a/tests/unit/cpi_template_test.go
+++ b/tests/unit/cpi_template_test.go
@@ -59,7 +59,7 @@ func TestCPITemplateRenderedDaemonset(t *testing.T) {
 					"global.prime.enabled":                "true",
 					"global.cattle.systemDefaultRegistry": "registry.rancher.com",
 				},
-				kubeVersion:   "1.30",
+				kubeVersion:   "1.36",
 				namespace:     "cpitest-" + strings.ToLower(random.UniqueId()),
 				releaseName:   "cpitest-" + strings.ToLower(random.UniqueId()),
 				chartRelPath:  cpiChart,
@@ -74,7 +74,7 @@ func TestCPITemplateRenderedDaemonset(t *testing.T) {
 				namespace:     "cpitest-" + strings.ToLower(random.UniqueId()),
 				releaseName:   "cpitest-" + strings.ToLower(random.UniqueId()),
 				chartRelPath:  cpiChart,
-				expectedImage: "rancher/mirrored-cloud-provider-vsphere:v1.35.0",
+				expectedImage: "rancher/mirrored-cloud-provider-vsphere:v1.35.1",
 			},
 		},
 		{
@@ -96,7 +96,7 @@ func TestCPITemplateRenderedDaemonset(t *testing.T) {
 				namespace:     "cpitest-" + strings.ToLower(random.UniqueId()),
 				releaseName:   "cpitest-" + strings.ToLower(random.UniqueId()),
 				chartRelPath:  cpiChart,
-				expectedImage: "rancher/mirrored-cloud-provider-vsphere:v1.33.0",
+				expectedImage: "rancher/mirrored-cloud-provider-vsphere:v1.33.1",
 			},
 		},
 		{

--- a/updatecli/updatecli.d/update-cpi-images.yaml
+++ b/updatecli/updatecli.d/update-cpi-images.yaml
@@ -1,0 +1,153 @@
+name: "Update Rancher vSphere CPI prime tags"
+
+sources:
+  cpiPrime136:
+    name: Get latest vSphere CPI 1.36 release tag
+    kind: githubrelease
+    spec:
+      owner: rancher
+      repository: image-build-cloud-provider-vsphere
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
+      typefilter:
+        release: true
+        draft: false
+        prerelease: false
+      versionfilter:
+        kind: regex
+        pattern: '^v1\.36\.[0-9]+-build[0-9]+$'
+
+  cpiPrime135:
+    name: Get latest vSphere CPI 1.35 release tag
+    kind: githubrelease
+    spec:
+      owner: rancher
+      repository: image-build-cloud-provider-vsphere
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
+      typefilter:
+        release: true
+        draft: false
+        prerelease: false
+      versionfilter:
+        kind: regex
+        pattern: '^v1\.35\.[0-9]+-build[0-9]+$'
+
+  cpiPrime134:
+    name: Get latest vSphere CPI 1.34 release tag
+    kind: githubrelease
+    spec:
+      owner: rancher
+      repository: image-build-cloud-provider-vsphere
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
+      typefilter:
+        release: true
+        draft: false
+        prerelease: false
+      versionfilter:
+        kind: regex
+        pattern: '^v1\.34\.[0-9]+-build[0-9]+$'
+
+  cpiPrime133:
+    name: Get latest vSphere CPI 1.33 release tag
+    kind: githubrelease
+    spec:
+      owner: rancher
+      repository: image-build-cloud-provider-vsphere
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
+      typefilter:
+        release: true
+        draft: false
+        prerelease: false
+      versionfilter:
+        kind: regex
+        pattern: '^v1\.33\.[0-9]+-build[0-9]+$'
+
+targets:
+  cpiPrimeTag136:
+    name: Update CPI cloudControllerManager primeTag for 1.36
+    kind: yaml
+    scmid: default
+    sourceid: cpiPrime136
+    spec:
+      file: charts/rancher-vsphere-cpi/values.yaml
+      key: versionOverrides[0].values.cloudControllerManager.primeTag
+
+  cpiPrimeTag135:
+    name: Update CPI cloudControllerManager primeTag for 1.35
+    kind: yaml
+    scmid: default
+    sourceid: cpiPrime135
+    spec:
+      file: charts/rancher-vsphere-cpi/values.yaml
+      key: versionOverrides[1].values.cloudControllerManager.primeTag
+
+  cpiPrimeTag134:
+    name: Update CPI cloudControllerManager primeTag for 1.34
+    kind: yaml
+    scmid: default
+    sourceid: cpiPrime134
+    spec:
+      file: charts/rancher-vsphere-cpi/values.yaml
+      key: versionOverrides[2].values.cloudControllerManager.primeTag
+
+  cpiPrimeTag133:
+    name: Update CPI cloudControllerManager primeTag for 1.33
+    kind: yaml
+    scmid: default
+    sourceid: cpiPrime133
+    spec:
+      file: charts/rancher-vsphere-cpi/values.yaml
+      key: versionOverrides[3].values.cloudControllerManager.primeTag
+
+  cpiPrimeTagTestNoRegistry:
+    name: Update CPI prime tag in tests without system default registry
+    kind: file
+    scmid: default
+    sourceid: cpiPrime136
+    spec:
+      file: tests/unit/cpi_template_test.go
+      matchpattern: 'expectedImage: "rancher/hardened-cloud-provider-vsphere:[^"]+"'
+      replacepattern: 'expectedImage: "rancher/hardened-cloud-provider-vsphere:{{ source "cpiPrime136" }}"'
+
+  cpiPrimeTagTestWithRegistry:
+    name: Update CPI prime tag in tests with system default registry
+    kind: file
+    scmid: default
+    sourceid: cpiPrime136
+    spec:
+      file: tests/unit/cpi_template_test.go
+      matchpattern: 'expectedImage: "registry.rancher.com/rancher/hardened-cloud-provider-vsphere:[^"]+"'
+      replacepattern: 'expectedImage: "registry.rancher.com/rancher/hardened-cloud-provider-vsphere:{{ source "cpiPrime136" }}"'
+
+scms:
+  default:
+    kind: github
+    spec:
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
+      user: '{{ .github.user }}'
+      email: '{{ .github.email }}'
+      owner: '{{ .github.owner }}'
+      repository: '{{ .github.repository }}'
+      branch: '{{ .github.branch }}'
+      commitusingapi: true
+
+actions:
+  default:
+    title: '[updatecli] Bump Rancher vSphere CPI Prime image tags'
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      automerge: false
+      mergemethod: squash
+      description: |
+        This automated PR updates the Rancher Prime image tag in the vSphere CPI chart.
+
+        Updated sources:
+        - hardened-cloud-provider-vsphere (1.36): {{ source "cpiPrime136" }}
+        - hardened-cloud-provider-vsphere (1.35): {{ source "cpiPrime135" }}
+        - hardened-cloud-provider-vsphere (1.34): {{ source "cpiPrime134" }}
+        - hardened-cloud-provider-vsphere (1.33): {{ source "cpiPrime133" }}

--- a/updatecli/updatecli.d/update-csi-images.yaml
+++ b/updatecli/updatecli.d/update-csi-images.yaml
@@ -1,4 +1,4 @@
-name: "Update Rancher vSphere CSI and CPI prime tags"
+name: "Update Rancher vSphere CSI prime tags"
 
 sources:
   csiDriverPrime:
@@ -80,22 +80,6 @@ sources:
       versionfilter:
         kind: semver
         pattern: ">=0.0.0-0"
-
-  cpiPrime:
-    name: Get latest vSphere CPI release tag
-    kind: githubrelease
-    spec:
-      owner: rancher
-      repository: image-build-cloud-provider-vsphere
-      token: '{{ requiredEnv .github.token }}'
-      username: '{{ requiredEnv .github.username }}'
-      typefilter:
-        release: true
-        draft: false
-        prerelease: false
-      versionfilter:
-        kind: regex
-        pattern: '^v[0-9]+\.[0-9]+\.[0-9]+-build[0-9]+$'
 
 targets:
   csiDriverPrimeTag:
@@ -234,35 +218,6 @@ targets:
       matchpattern: 'registry.rancher.com/rancher/hardened-csi-provisioner:[^"]+'
       replacepattern: 'registry.rancher.com/rancher/hardened-csi-provisioner:{{ source "csiProvisionerPrime" }}'
 
-  cpiPrimeTag:
-    name: Update CPI cloudControllerManager primeTag
-    kind: yaml
-    scmid: default
-    sourceid: cpiPrime
-    spec:
-      file: charts/rancher-vsphere-cpi/values.yaml
-      key: cloudControllerManager.primeTag
-
-  cpiPrimeTagTestNoRegistry:
-    name: Update CPI prime tag in tests without system default registry
-    kind: file
-    scmid: default
-    sourceid: cpiPrime
-    spec:
-      file: tests/unit/cpi_template_test.go
-      matchpattern: 'expectedImage: "rancher/hardened-cloud-provider-vsphere:[^"]+"'
-      replacepattern: 'expectedImage: "rancher/hardened-cloud-provider-vsphere:{{ source "cpiPrime" }}"'
-
-  cpiPrimeTagTestWithRegistry:
-    name: Update CPI prime tag in tests with system default registry
-    kind: file
-    scmid: default
-    sourceid: cpiPrime
-    spec:
-      file: tests/unit/cpi_template_test.go
-      matchpattern: 'expectedImage: "registry.rancher.com/rancher/hardened-cloud-provider-vsphere:[^"]+"'
-      replacepattern: 'expectedImage: "registry.rancher.com/rancher/hardened-cloud-provider-vsphere:{{ source "cpiPrime" }}"'
-
 scms:
   default:
     kind: github
@@ -278,14 +233,14 @@ scms:
 
 actions:
   default:
-    title: '[updatecli] Bump Rancher vSphere CSI and CPI Prime image tags'
+    title: '[updatecli] Bump Rancher vSphere CSI Prime image tags'
     kind: github/pullrequest
     scmid: default
     spec:
       automerge: false
       mergemethod: squash
       description: |
-        This automated PR updates Rancher Prime image tags in the vSphere CSI and CPI charts.
+        This automated PR updates Rancher Prime image tags in the vSphere CSI chart.
 
         Updated sources:
         - hardened-vsphere-csi-driver: {{ source "csiDriverPrime" }}
@@ -296,4 +251,3 @@ actions:
         - hardened-csi-provisioner: {{ source "csiProvisionerPrime" }}
         - hardened-csi-snapshotter: {{ source "csiSnapshotterPrime" }}
         - hardened-csi-node-driver-registrar: {{ source "nodeDriverRegistrarPrime" }}
-        - hardened-cloud-provider-vsphere: {{ source "cpiPrime" }}


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

#### Pull Request Checklist ####

- [ ] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [ ] Chart version has been incremented (if necessary)
- [ ] That helm lint and pack run successfully on the chart.
- [ ] Deployment of the chart has been tested and verified that it functions as expected.
- [ ] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####
- Revert d292f704d841611523f9cae39e41094eb29486be, now that CPI needs a full set of targets, keeping the CPI and CSI updates separate is a better idea. 
<!-- New image, version bump. script update, etc etc -->

#### Linked Issues ####

<!-- Link any related issues, pull-requests, or commit hashes that are relevant to this pull request.  -->

#### Additional Notes ####

<!-- Any additional details / test results / etc -->

#### After the PR is merged ####

Once the PR is merged, typically upon a new release, the necessary teams will be notified via Slack hook to perform the RKE2 Charts and RKE2 changes. Any developer working on this issue is not responsible for updating RKE2 Charts or RKE2.