### PR TITLE
feat(daemonset): Add support for resources

### DIFF
--- a/charts/rancher-vsphere-cpi/Chart.yaml
+++ b/charts/rancher-vsphere-cpi/Chart.yaml
@@ -21,4 +21,4 @@ maintainers:
 name: rancher-vsphere-cpi
 sources:
 - https://github.com/kubernetes/cloud-provider-vsphere
-version: 1.15.2
+version: 1.15.3

--- a/charts/rancher-vsphere-cpi/templates/daemonset.yaml
+++ b/charts/rancher-vsphere-cpi/templates/daemonset.yaml
@@ -100,8 +100,7 @@ spec:
               name: vsphere-config-volume
               readOnly: true
           resources:
-            requests:
-              cpu: 200m
+            {{- toYaml .Values.cloudControllerManager.resources | nindent 12 }}
           {{- if or (.Values.cloudControllerManager.env) (.Values.global.ipFamily) }}
           env:
           {{- if .Values.global.ipFamily }}

--- a/charts/rancher-vsphere-cpi/values.yaml
+++ b/charts/rancher-vsphere-cpi/values.yaml
@@ -112,6 +112,10 @@ cloudControllerManager:
   rbac:
     enabled: true
   env: []
+  # Container resource requests and limits
+  resources:
+    requests:
+      cpu: 200m
   # Pod DNS policy
   # Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
   # Note that CPI pods run with host network and need to communicate with the


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] Chart version has been incremented (if necessary)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####
This PR introduce support for `resources` in the `cpi`.

Current setup doesn't allowed to set limits/requests for the `daemonset`

Default value for CPU in the `values.yaml` stayed 200, so no breaking change.