### PR TITLE
feat(deployment): Add support for 'topologySpreadConstraints'

### DIFF
--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -21,4 +21,4 @@ maintainers:
 name: rancher-vsphere-csi
 sources:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.7.2-rancher3
+version: 3.7.2-rancher4

--- a/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
+++ b/charts/rancher-vsphere-csi/templates/controller/deployment.yaml
@@ -65,6 +65,10 @@ spec:
                 - "windows"
       {{- end }}
       {{- end }}
+      {{- with .Values.csiController.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.csiController.tolerations }}
       tolerations: {{ include "linux-node-tolerations" . | nindent 8 }}
       {{- with .Values.csiController.tolerations }}

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -163,6 +163,15 @@ csiController:
   #           operator: In
   #           values:
   #           - us-west
+  ## Topology spread constraints for controller pod assignment
+  ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+  topologySpreadConstraints: []
+  # - maxSkew: 1
+  #   topologyKey: kubernetes.io/hostname
+  #   whenUnsatisfiable: DoNotSchedule
+  #   labelSelector:
+  #     matchLabels:
+  #       app: vsphere-csi-controller
   # Uncomment below toleration if you need an aggressive pod eviction in case when
   # node becomes not-ready or unreachable. Default is 300 seconds if not specified.
   tolerations: []


### PR DESCRIPTION
#### Pull Request Checklist ####

- [ ] Any new images or tags consumed by charts has been added [here](https://github.com/rancher/image-mirror)
- [x] Chart version has been incremented (if necessary)
- [x] That helm lint and pack run successfully on the chart.
- [x] Deployment of the chart has been tested and verified that it functions as expected.
- [x] Changes to scripting or CI config have been tested to the best of your ability

#### Types of Change ####
This PR introduce support for `topologySpreadConstraints` in the `csi`.

It allows to control how pods are spread across  cluster among failure-domains such as regions or zones.