### PR TITLE
Bump hardened-csi-provisioner image to v4.0.1-build20260730

### DIFF
--- a/charts/rancher-vsphere-csi/Chart.yaml
+++ b/charts/rancher-vsphere-csi/Chart.yaml
@@ -21,4 +21,4 @@ maintainers:
 name: rancher-vsphere-csi
 sources:
 - https://github.com/kubernetes-sigs/vsphere-csi-driver
-version: 3.7.2-rancher4
+version: 3.7.2-rancher5

--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -110,7 +110,7 @@ csiController:
       repository: rancher/mirrored-sig-storage-csi-provisioner
       primeRepository: rancher/hardened-csi-provisioner
       tag: latest
-      primeTag: v6.3.0-build20260722
+      primeTag: v4.0.1-build20260730
       imagePullPolicy: ""
       additionalArgs: []
       resources: {}

--- a/tests/unit/csi_template_test.go
+++ b/tests/unit/csi_template_test.go
@@ -483,7 +483,7 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 					"registry.rancher.com/rancher/hardened-vsphere-csi-driver:v3.7.2-build20260722",
 					"registry.rancher.com/rancher/hardened-livenessprobe:v2.19.0-build20260722",
 					"registry.rancher.com/rancher/hardened-vsphere-csi-syncer:v3.7.2-build20260722",
-					"registry.rancher.com/rancher/hardened-csi-provisioner:v6.3.0-build20260722",
+					"registry.rancher.com/rancher/hardened-csi-provisioner:v4.0.1-build20260730",
 				},
 			},
 		},


### PR DESCRIPTION
Updates the CSI provisioner hardened (prime) image to the newly cut `v4.0.1-build20260730` tag.

## Changes
- `charts/rancher-vsphere-csi/values.yaml`: bump `csiProvisioner.primeTag` from `v6.3.0-build20260722` to `v4.0.1-build20260730`
- `charts/rancher-vsphere-csi/Chart.yaml`: patch bump chart version `3.7.2-rancher4` -> `3.7.2-rancher5`
- `tests/unit/csi_template_test.go`: update the expected image tag

Unit tests pass locally.