### PR TITLE
Align CSI Prime image tags with mirrored versions

### DIFF
--- a/charts/rancher-vsphere-csi/values.yaml
+++ b/charts/rancher-vsphere-csi/values.yaml
@@ -50,7 +50,7 @@ csiController:
       repository: rancher/mirrored-sig-storage-csi-attacher
       primeRepository: rancher/hardened-csi-attacher
       tag: latest
-      primeTag: v4.12.0-build20260722
+      primeTag: v4.9.0-build20260731
       imagePullPolicy: ""
       additionalArgs: []
       resources: {}
@@ -65,7 +65,7 @@ csiController:
       repository: rancher/mirrored-sig-storage-csi-resizer
       primeRepository: rancher/hardened-csi-resizer
       tag: latest
-      primeTag: v2.2.1-build20260722
+      primeTag: v1.12.0-build20260731
       imagePullPolicy: ""
       additionalArgs: []
       resources: {}
@@ -80,7 +80,7 @@ csiController:
       repository: rancher/mirrored-sig-storage-livenessprobe
       primeRepository: rancher/hardened-livenessprobe
       tag: latest
-      primeTag: v2.19.0-build20260722
+      primeTag: v2.15.0-build20260731
       imagePullPolicy: ""
       additionalArgs: []
       resources: {}
@@ -261,7 +261,7 @@ csiNode:
       repository: rancher/mirrored-sig-storage-csi-node-driver-registrar
       primeRepository: rancher/hardened-csi-node-driver-registrar
       tag: latest
-      primeTag: v2.17.0-build20260722
+      primeTag: v2.13.0-build20260731
       imagePullPolicy: ""
       additionalArgs: []
       resources: {}
@@ -276,7 +276,7 @@ csiNode:
       repository: rancher/mirrored-sig-storage-livenessprobe
       primeRepository: rancher/hardened-livenessprobe
       tag: latest
-      primeTag: v2.19.0-build20260722
+      primeTag: v2.15.0-build20260731
       imagePullPolicy: ""
       additionalArgs: []
       resources: {}

--- a/tests/unit/csi_template_test.go
+++ b/tests/unit/csi_template_test.go
@@ -58,9 +58,9 @@ func TestCSITemplateRenderedNodeDaemonset(t *testing.T) {
 				chartRelPath:   csiChart,
 				windowsEnabled: false,
 				expectedImages: []string{
-					"registry.rancher.com/rancher/hardened-csi-node-driver-registrar:v2.17.0-build20260722",
+					"registry.rancher.com/rancher/hardened-csi-node-driver-registrar:v2.13.0-build20260731",
 					"registry.rancher.com/rancher/hardened-vsphere-csi-driver:v3.7.2-build20260722",
-					"registry.rancher.com/rancher/hardened-livenessprobe:v2.19.0-build20260722",
+					"registry.rancher.com/rancher/hardened-livenessprobe:v2.15.0-build20260731",
 				},
 			},
 		},
@@ -479,9 +479,9 @@ func TestCSITemplateRenderedControllerDeployment(t *testing.T) {
 				chartRelPath:      csiChart,
 				csiResizerEnabled: false,
 				expectedImages: []string{
-					"registry.rancher.com/rancher/hardened-csi-attacher:v4.12.0-build20260722",
+					"registry.rancher.com/rancher/hardened-csi-attacher:v4.9.0-build20260731",
 					"registry.rancher.com/rancher/hardened-vsphere-csi-driver:v3.7.2-build20260722",
-					"registry.rancher.com/rancher/hardened-livenessprobe:v2.19.0-build20260722",
+					"registry.rancher.com/rancher/hardened-livenessprobe:v2.15.0-build20260731",
 					"registry.rancher.com/rancher/hardened-vsphere-csi-syncer:v3.7.2-build20260722",
 					"registry.rancher.com/rancher/hardened-csi-provisioner:v4.0.1-build20260730",
 				},

--- a/updatecli/updatecli.d/update-csi-images.yaml
+++ b/updatecli/updatecli.d/update-csi-images.yaml
@@ -19,7 +19,11 @@ sources:
       tagfilter: '^v[0-9]+\.[0-9]+\.[0-9]+-build[0-9]+$'
       versionfilter:
         kind: semver
-        pattern: ">=0.0.0-0"
+        # Pin to the v4.9.x line to match the csi-attacher version pinned by the
+        # vSphere CSI driver manifest. The hardened repo also publishes a newer
+        # v4.12.0 line, so an unconstrained ">=0.0.0-0" filter drifts prime ahead
+        # of mirrored.
+        pattern: '>=4.9.0-0 <4.10.0-0'
 
   csiResizerPrime:
     name: Get latest hardened CSI resizer tag
@@ -29,7 +33,11 @@ sources:
       tagfilter: '^v[0-9]+\.[0-9]+\.[0-9]+-build[0-9]+$'
       versionfilter:
         kind: semver
-        pattern: ">=0.0.0-0"
+        # Pin to the v1.12.x line to match the csi-resizer version pinned by the
+        # vSphere CSI driver manifest. The hardened repo also publishes a v2.2.1
+        # line that does not correspond to any upstream external-resizer release,
+        # so an unconstrained ">=0.0.0-0" filter drifts prime ahead of mirrored.
+        pattern: '>=1.12.0-0 <1.13.0-0'
 
   livenessProbePrime:
     name: Get latest hardened livenessprobe tag
@@ -39,7 +47,11 @@ sources:
       tagfilter: '^v[0-9]+\.[0-9]+\.[0-9]+-build[0-9]+$'
       versionfilter:
         kind: semver
-        pattern: ">=0.0.0-0"
+        # Pin to the v2.15.x line to match the livenessprobe version pinned by
+        # the vSphere CSI driver manifest. The hardened repo also publishes a
+        # newer v2.19.0 line, so an unconstrained ">=0.0.0-0" filter drifts prime
+        # ahead of mirrored.
+        pattern: '>=2.15.0-0 <2.16.0-0'
 
   vsphereSyncerPrime:
     name: Get latest hardened vSphere CSI syncer tag
@@ -79,7 +91,11 @@ sources:
       tagfilter: '^v[0-9]+\.[0-9]+\.[0-9]+-build[0-9]+$'
       versionfilter:
         kind: semver
-        pattern: ">=0.0.0-0"
+        # Pin to the v2.13.x line to match the node-driver-registrar version
+        # pinned by the vSphere CSI driver manifest. The hardened repo also
+        # publishes a newer v2.17.0 line, so an unconstrained ">=0.0.0-0" filter
+        # drifts prime ahead of mirrored.
+        pattern: '>=2.13.0-0 <2.14.0-0'
 
 targets:
   csiDriverPrimeTag:


### PR DESCRIPTION
### Problem

The hardened (Rancher Prime) CSI sidecar image tags in `rancher-vsphere-csi` had drifted **ahead** of the community `mirrored-*` tags. The mirrored tags track the exact sidecar versions pinned by the upstream [vSphere CSI driver v3.7.2 manifest](https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/v3.7.2/manifests/vanilla/vsphere-csi-driver.yaml), but the `primeTag`s did not:

| Sidecar | upstream v3.7.2 / mirrored | previous primeTag |
| --- | --- | --- |
| csi-resizer | v1.12.0 | **v2.2.1** |
| csi-attacher | v4.9.0 | v4.12.0 |
| livenessprobe | v2.15.0 | v2.19.0 |
| node-driver-registrar | v2.13.0 | v2.17.0 |

The most severe was **csi-resizer**: the `hardened-csi-resizer` repo only published a `v2.2.1-build*` line, which does not correspond to any upstream `external-resizer` release (upstream has no v2.x). vsphere-csi-driver v3.7.2 pins external-resizer **v1.12.0**.

### Root cause

`updatecli/updatecli.d/update-csi-images.yaml` selected the newest hardened build for each sidecar using an unconstrained `versionfilter` (`pattern: ">=0.0.0-0"`), completely decoupled from the version the driver manifest pins. So each Prime tag floated to "latest hardened build" regardless of the driver's sidecar version.

### Changes

- Downgrade the four drifted `primeTag`s to hardened builds that match the driver-pinned versions:
  - `hardened-csi-resizer`: `v2.2.1-build20260722` → `v1.12.0-build20260731`
  - `hardened-csi-attacher`: `v4.12.0-build20260722` → `v4.9.0-build20260731`
  - `hardened-livenessprobe`: `v2.19.0-build20260722` → `v2.15.0-build20260731` (controller + node)
  - `hardened-csi-node-driver-registrar`: `v2.17.0-build20260722` → `v2.13.0-build20260731`
- Constrain the corresponding updatecli `versionfilter`s to the matching version line so the tags stay aligned on future automated runs.
- Update the Prime image assertions in `tests/unit/csi_template_test.go` accordingly.

New hardened builds referenced:
- rancher/image-build-csi-resizer `v1.12.0-build20260731`
- rancher/image-build-csi-attacher `v4.9.0-build20260731`
- rancher/image-build-livenessprobe `v2.15.0-build20260731`
- rancher/image-build-csi-node-driver-registrar `v2.13.0-build20260731`

All four tags are confirmed present in `registry.rancher.com`.

### Testing

`go test -tags helm ./tests/unit` passes, including the Prime image-tag assertions.
